### PR TITLE
39 re add webrtc ready callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ AdapterJS provides polyfills and cross-browser helpers for WebRTC. It wraps arou
 
 ## Using AdapterJS
 
+#### Integration
+
+The integration with your application consists in a few simple steps, described in the  [Temasys Plugin Documentation](https://temasys.atlassian.net/wiki/display/TWPP/How+to+integrate+the+plugin+with+your+website).
+
 #### Helper functions
 
 ##### `attachMediaStream(element, stream)`

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -12,6 +12,21 @@ AdapterJS.options = {};
 // AdapterJS version
 AdapterJS.VERSION = '@@version';
 
+// This function will be called when the WebRTC API is ready to be used
+// Whether it is the native implementation (Chrome, Firefox, Opera) or 
+// the plugin
+// You may Override this function to synchronise the start of your application
+// with the WebRTC API being ready.
+// If you decide not to override use this synchronisation, it may result in 
+// an extensive CPU usage on the plugin start (once per tab loaded) 
+// Params:
+//    - isUsingPlugin: true is the WebRTC plugin is being used, false otherwise
+//
+AdapterJS.WebRTCReadyCallback = AdapterJS.WebRTCReadyCallback || function(isUsingPlugin) {
+  // The WebRTC API is ready.
+  // Override me and do whatever you want here
+};
+
 // Plugin namespace
 AdapterJS.WebRTCPlugin = AdapterJS.WebRTCPlugin || {};
 
@@ -72,21 +87,6 @@ AdapterJS.WebRTCPlugin.PLUGIN_STATES = {
 // Current state of the plugin. You cannot use the plugin before this is
 // equal to AdapterJS.WebRTCPlugin.PLUGIN_STATES.READY
 AdapterJS.WebRTCPlugin.pluginState = AdapterJS.WebRTCPlugin.PLUGIN_STATES.NONE;
-
-// This function will be called when the WebRTC API is ready to be used
-// Whether it is the native implementation (Chrome, Firefox, Opera) or 
-// the plugin
-// You may Override this function to synchronise the start of your application
-// with the WebRTC API being ready.
-// If you decide not to override use this synchronisation, it may result in 
-// an extensive CPU usage on the plugin start (once per tab loaded) 
-// Params:
-//    - isUsingPlugin: true is the WebRTC plugin is being used, false otherwise
-//
-// AdapterJS.WebRTCReadyCallback = function(isUsingPlugin) {
-//   // The WebRTC API is ready.
-//   // Override me and do whatever you want here
-// };
 
 // True is AdapterJS.WebRTCReadyCallback was already called, false otherwise
 // Used to make sure AdapterJS.WebRTCReadyCallback is only called once

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1,5 +1,5 @@
 // Adapter's interface.
-AdapterJS = AdapterJS || {};
+var AdapterJS = AdapterJS || {};
 
 AdapterJS.options = {};
 


### PR DESCRIPTION
I added ```AdapterJS.WebRTCReadyCallback``` which will be called whenever the WebRTC API is ready (on any browser, not only for the plugin).
See comments in the code for more details.

The blocking loop waiting for the plugin to be ready is still present in case people don't want to use this callback.

I added a link to the existing plugin documentation where this will be documented (today hopefully)

This needs to be tested against SkylinkJS before merging