### PR TITLE
Fix AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCb not being overridable

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -924,12 +924,14 @@ if (navigator.mozGetUserMedia) {
     AdapterJS.WebRTCPlugin.injectPlugin();
   };
 
-  AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCb = function() {
-    AdapterJS.addEvent(document, 
-                      'readystatechange',
-                       AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCbPriv);
-    AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCbPriv();
-  };
+  if (AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCb === null) {
+    AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCb = function() {
+      AdapterJS.addEvent(document,
+                        'readystatechange',
+                         AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCbPriv);
+      AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCbPriv();
+    };
+  }
 
   AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCbPriv = function () {
     if (AdapterJS.options.hidePluginInstallPrompt) {

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -924,14 +924,13 @@ if (navigator.mozGetUserMedia) {
     AdapterJS.WebRTCPlugin.injectPlugin();
   };
 
-  if (AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCb === null) {
-    AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCb = function() {
+  AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCb = AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCb ||
+    function() {
       AdapterJS.addEvent(document,
                         'readystatechange',
                          AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCbPriv);
       AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCbPriv();
     };
-  }
 
   AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCbPriv = function () {
     if (AdapterJS.options.hidePluginInstallPrompt) {


### PR DESCRIPTION
As per the comments in `adapter.js`, `AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCb` should be overridable. However, it wasn't because `AdapterJS.WebRTCPlugin.pluginNeededButNotInstalledCb` was being assigned unconditionally further down the code. This pull request fixes this.