### PR TITLE
AJS-189: changing integration process of AJS: call immediatly if webr…

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -90,7 +90,7 @@ AdapterJS.WebRTCPlugin.pluginState = AdapterJS.WebRTCPlugin.PLUGIN_STATES.NONE;
 
 // True is AdapterJS.onwebrtcready was already called, false otherwise
 // Used to make sure AdapterJS.onwebrtcready is only called once
-AdapterJS.onwebrtcreadyDone = false;
+AdapterJS.webrtcready = false;
 
 // Log levels for the plugin. 
 // To be set by calling AdapterJS.WebRTCPlugin.setLogLevel
@@ -150,8 +150,8 @@ __TemWebRTCReady0 = function () {
 };
 
 AdapterJS.maybeThroughWebRTCReady = function() {
-  if (!AdapterJS.onwebrtcreadyDone) {
-    AdapterJS.onwebrtcreadyDone = true;
+  if (!AdapterJS.webrtcready) {
+    AdapterJS.webrtcready = true;
 
     if (typeof(AdapterJS.onwebrtcready) === 'function') {
       AdapterJS.onwebrtcready(AdapterJS.WebRTCPlugin.plugin !== null);


### PR DESCRIPTION
IMPORTANT: @serrynaimo , @letchoo , what do you think

I realized that if AJS was imported before the onwebrtcready callback was defined, Chrome and firefox would not work. The callback is always done before being overridden by the app.

I suggest we display AdapterJS.webrtcready publicly, and change the integration process from

```
// You should define this callback BEFORE you import AdapterJS, otherwise it might be called before your callback is ready.
 
var AdapterJS = AdapterJS || {}; // this is to make sure AdapterJS is defined before setting the callback
AdapterJS.onwebrtcready = function(isUsingPlugin) {
    // The WebRTC API is ready.
    //isUsingPlugin: true is the WebRTC plugin is being used, false otherwise
    getUserMedia(constraints, successCb, failCb);
};
```

To

```
var AdapterJS = AdapterJS || {};
if (AdapterJS.webrtcready) {
    getUserMedia(constraints, successCb, failCb);
} else {
  AdapterJS.onwebrtcready = function(isUsingPlugin) {
    // The WebRTC API is ready.
    //isUsingPlugin: true is the WebRTC plugin is being used, false otherwise
    getUserMedia(constraints, successCb, failCb);
  }
}
```