### PR TITLE
AJS-231: changed <video> size copy strategy to support hidden elements

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1044,16 +1044,13 @@ if (navigator.mozGetUserMedia) {
 
         var height = '';
         var width = '';
-        if (element.getBoundingClientRect) {
-          var rectObject = element.getBoundingClientRect();
-          width = rectObject.width + 'px';
-          height = rectObject.height + 'px';
+        if (element.clientWidth || element.clientHeight) {
+          width = element.clientWidth;
+          height = element.clientHeight;
         }
-        else if (element.width) {
+        else if (element.width || element.height) {
           width = element.width;
           height = element.height;
-        } else {
-          // TODO: What scenario could bring us here?
         }
 
         element.parentNode.insertBefore(frag, element);


### PR DESCRIPTION
@letchoo 
We had feedbacks informing us that the <video> sizes weren't copied properly when the element was hidden of in a hidden div:

Scenario:
- have a <video> element in a hidden <div>
- set the <video> element's size to 800x600px
- attachMediaStream on it
- unhide the div

Expected:
- the plugin <object> is 800x600px

Observed:
- the plugin <object> is 0x0px

I think this should fix the issue.
clientWith and clientHeight are computed values, so when the element is hidden, they have a value of 0.