### PR TITLE
AJS-230 added test to pop plugin <object> in and out of the DOM

### DIFF
--- a/tests/unit/Plugin.object.stability.spec.js
+++ b/tests/unit/Plugin.object.stability.spec.js
@@ -1,0 +1,85 @@
+var expect = chai.expect;
+var assert = chai.assert;
+var should = chai.should;
+
+// Test timeouts
+var testTimeout = 120000;
+
+// Get User Media timeout
+var gUMTimeout = 15000;
+
+// Test item timeout
+var testItemTimeout = 120000;
+
+// Stress test, popping plugin elements in and out 'POP_REQUESTS' times
+var POP_REQUESTS = 100;
+
+// !!! THIS TEST ONLY APPLIES FOR PLUGIN-BASED BROWSERS !!!
+if(webrtcDetectedBrowser === 'safari' || webrtcDetectedBrowser === 'IE') {
+
+  describe('Plugin Object | Stability', function() {
+    this.timeout(testTimeout);
+
+    /* Attributes */
+    var video = null;
+    var stream = null;
+
+    /* WebRTC Object should be initialized in Safari/IE Plugin */
+    before(function (done) {
+      this.timeout(gUMTimeout);
+
+      AdapterJS.webRTCReady(function() { 
+        done();
+      });
+    });
+
+    beforeEach(function (done) {
+      this.timeout(gUMTimeout);
+
+      window.navigator.getUserMedia({
+        audio: true,
+        video: true
+
+      }, function (data) {
+        stream = data;
+        video = document.createElement('video');
+        document.body.appendChild(video);
+        done();
+
+      }, function (error) {
+        throw error;
+      });
+
+    });
+
+    afterEach(function () {
+      document.body.removeChild(video);
+      stream = null;
+    });
+
+    it('Pop element N times', function(done) {
+      this.timeout(testItemTimeout);
+
+      var popCount = 0;
+      var timeout;
+
+      var replaceVideoElement = function() {
+        clearTimeout(timeout);
+        document.body.removeChild(video);
+        video = document.createElement('video');
+        document.body.appendChild(video);
+        video.onplay = replaceVideoElement;
+        video = attachMediaStream(video, stream);
+        timeout = setTimeout(replaceVideoElement, 500);
+
+        expect(video.valid).to.equal(true);
+        if (++popCount >= POP_REQUESTS) {
+          clearTimeout(timeout);
+          done();
+        }
+      }
+      replaceVideoElement();
+    });
+
+  }); // describe('Plugin Object | Stability'
+} // if(webrtcDetectedBrowser === 'safari' || webrtcDetectedBrowser === 'IE') 


### PR DESCRIPTION
This test pops plugin <object> in and out of the DOM.
This is to check for crashes when objects are added and remove to often.