### PR TITLE
Ajs 227 AdapterJS generation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-compress');
     grunt.loadNpmTasks('grunt-contrib-yuidoc');
     grunt.loadNpmTasks('grunt-replace');
+    grunt.loadNpmTasks('grunt-include-replace');
     grunt.loadNpmTasks('grunt-karma');
 
     grunt.initConfig({
@@ -105,6 +106,22 @@ module.exports = function(grunt) {
             ],
             dest: '<%= production %>/'
           }]
+        }
+      },
+
+      includereplace: {
+        production: {
+          options: {
+            // Task-specific options go here. 
+            prefix: '@@',
+            includesDir: '<%= source %>/',
+          },
+          // Files to perform replacements and includes with 
+          src: [
+            '<%= production %>/*.js',
+            ],
+          // Destination directory to copy files to 
+          dest: './'
         }
       },
       
@@ -248,6 +265,7 @@ module.exports = function(grunt) {
         'clean:production',
         'concat',
         'replace:production',
+        'includereplace:production',
         'uglify'
     ]);
 
@@ -256,6 +274,7 @@ module.exports = function(grunt) {
         'clean:production',
         'concat',
         'replace',
+        'includereplace',
         'uglify',
         'yuidoc'
     ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,6 +23,9 @@ module.exports = function(grunt) {
 
       bamboo: 'bamboo',
 
+      pluginInfoRoot: grunt.option('pluginInfoRoot') || '<%= source %>',
+      pluginInfoFile: grunt.option('pluginInfoFile') || 'pluginInfo.js',
+
       clean: {
         production: ['<%= production %>/'],
         bamboo: ['<%= bamboo %>/'],
@@ -114,7 +117,7 @@ module.exports = function(grunt) {
           options: {
             // Task-specific options go here. 
             prefix: '@@',
-            includesDir: '<%= source %>/',
+            includesDir: '<%= pluginInfoRoot %>/',
           },
           // Files to perform replacements and includes with 
           src: [
@@ -260,7 +263,19 @@ module.exports = function(grunt) {
         grunt.log.writeln('bamboo/vars file successfully created');
     });
 
+    grunt.registerTask('CheckPluginInfo', 'Checks for existing config file', function() {
+      var fullPath = grunt.config.get('pluginInfoRoot') + '/' + grunt.config.get('pluginInfoFile');
+      grunt.verbose.writeln('Checking that the plugin info file exists.');
+      grunt.verbose.writeln('Privided Path : ' + fullPath);
+      if (grunt.file.exists(fullPath)) {
+        grunt.log.oklns('Plugin info file found.');
+      } else {
+        grunt.fail.fatal('Plugin info file does not exist : ' + fullPath);
+      }
+    });
+
     grunt.registerTask('dev', [
+        'CheckPluginInfo',
         'versionise',
         'clean:production',
         'concat',
@@ -270,6 +285,7 @@ module.exports = function(grunt) {
     ]);
 
     grunt.registerTask('publish', [
+        'CheckPluginInfo',
         'versionise',
         'clean:production',
         'concat',

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "grunt-contrib-jshint": "0.11.2",
     "grunt-contrib-uglify": "0.9.1",
     "grunt-contrib-yuidoc": "0.7.0",
+    "grunt-include-replace": "^3.2.0",
     "grunt-karma": "^0.12.0",
     "grunt-replace": "0.7.9",
     "karma": "^0.13.2",

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -53,22 +53,7 @@ AdapterJS.webRTCReady = function (callback) {
 AdapterJS.WebRTCPlugin = AdapterJS.WebRTCPlugin || {};
 
 // The object to store plugin information
-AdapterJS.WebRTCPlugin.pluginInfo = {
-  prefix : 'Tem',
-  plugName : 'TemWebRTCPlugin',
-  pluginId : 'plugin0',
-  type : 'application/x-temwebrtcplugin',
-  onload : '__TemWebRTCReady0',
-  portalLink : 'http://skylink.io/plugin/',
-  downloadLink : null, //set below
-  companyName: 'Temasys'
-};
-if(!!navigator.platform.match(/^Mac/i)) {
-  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = 'http://bit.ly/1n77hco';
-}
-else if(!!navigator.platform.match(/^Win/i)) {
-  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = 'http://bit.ly/1kkS4FN';
-}
+@@include('pluginInfo.js', {})
 
 AdapterJS.WebRTCPlugin.TAGS = {
   NONE  : 'none',

--- a/source/pluginInfo.js
+++ b/source/pluginInfo.js
@@ -1,0 +1,16 @@
+AdapterJS.WebRTCPlugin.pluginInfo = {
+  prefix : 'Tem',
+  plugName : 'TemWebRTCPlugin',
+  pluginId : 'plugin0',
+  type : 'application/x-temwebrtcplugin',
+  onload : '__TemWebRTCReady0',
+  portalLink : 'http://skylink.io/plugin/',
+  downloadLink : null, //set below
+  companyName: 'Temasys'
+};
+if(!!navigator.platform.match(/^Mac/i)) {
+  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = 'http://bit.ly/1n77hco';
+}
+else if(!!navigator.platform.match(/^Win/i)) {
+  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = 'http://bit.ly/1kkS4FN';
+}


### PR DESCRIPTION
This is so that the plugin config can be changed very easily (see JIRA)

* Removed the pluginInfo from AJS
* Moved it to a separate file
* compiling both on grunt publish

!!! This means that one cannot use source/adapter.js directly but has to use the compiled version !!!