### PR TITLE
AJS-237 call enableSoundTracks only when defined.

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -986,7 +986,9 @@ if (navigator.mozGetUserMedia) {
       if (stream === null) {
         streamId = '';
       } else {
-        stream.enableSoundTracks(true); // TODO: remove on 0.12.0
+        if (typeof stream.enableSoundTracks !== 'undefined') {
+          stream.enableSoundTracks(true);
+        }
         streamId = stream.id;
       }
 


### PR DESCRIPTION
stream::enableSoundTrack is deprecated starting on plugin verion 0.8.862.
Call it only when it is defined in prevision of the function being removed.