### PR TITLE
AJS-242 createiceserver throws warnings on ff43

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -574,16 +574,16 @@ if ( navigator.mozGetUserMedia
 
     createIceServer = function (url, username, password) {
       console.warn('createIceServer is deprecated. It should be replaced with an application level implementation.');
-      
+      // Note: Google's import of AJS will auto-reverse to 'url': '...' for FF < 38
       var iceServer = null;
       var urlParts = url.split(':');
       if (urlParts[0].indexOf('stun') === 0) {
         iceServer = { urls : [url] };
       } else if (urlParts[0].indexOf('turn') === 0) {
         if (webrtcDetectedVersion < 27) {
-          var turn_urlParts = url.split('?');
-          if (turn_urlParts.length === 1 ||
-            turn_urlParts[1].indexOf('transport=udp') === 0) {
+          var turnUrlParts = url.split('?');
+          if (turnUrlParts.length === 1 ||
+            turnUrlParts[1].indexOf('transport=udp') === 0) {
             iceServer = {
               urls : [turn_urlParts[0]],
               credential : password,

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -576,23 +576,23 @@ if ( navigator.mozGetUserMedia
       console.warn('createIceServer is deprecated. It should be replaced with an application level implementation.');
       
       var iceServer = null;
-      var url_parts = url.split(':');
-      if (url_parts[0].indexOf('stun') === 0) {
-        iceServer = { url : url };
-      } else if (url_parts[0].indexOf('turn') === 0) {
+      var urlParts = url.split(':');
+      if (urlParts[0].indexOf('stun') === 0) {
+        iceServer = { urls : [url] };
+      } else if (urlParts[0].indexOf('turn') === 0) {
         if (webrtcDetectedVersion < 27) {
-          var turn_url_parts = url.split('?');
-          if (turn_url_parts.length === 1 ||
-            turn_url_parts[1].indexOf('transport=udp') === 0) {
+          var turn_urlParts = url.split('?');
+          if (turn_urlParts.length === 1 ||
+            turn_urlParts[1].indexOf('transport=udp') === 0) {
             iceServer = {
-              url : turn_url_parts[0],
+              urls : [turn_urlParts[0]],
               credential : password,
               username : username
             };
           }
         } else {
           iceServer = {
-            url : url,
+            urls : [url],
             credential : password,
             username : username
           };
@@ -618,10 +618,10 @@ if ( navigator.mozGetUserMedia
       console.warn('createIceServer is deprecated. It should be replaced with an application level implementation.');
       
       var iceServer = null;
-      var url_parts = url.split(':');
-      if (url_parts[0].indexOf('stun') === 0) {
+      var urlParts = url.split(':');
+      if (urlParts[0].indexOf('stun') === 0) {
         iceServer = { 'url' : url };
-      } else if (url_parts[0].indexOf('turn') === 0) {
+      } else if (urlParts[0].indexOf('turn') === 0) {
         iceServer = {
           'url' : url,
           'credential' : password,
@@ -875,13 +875,13 @@ if ( navigator.mozGetUserMedia
 
     createIceServer = function (url, username, password) {
       var iceServer = null;
-      var url_parts = url.split(':');
-      if (url_parts[0].indexOf('stun') === 0) {
+      var urlParts = url.split(':');
+      if (urlParts[0].indexOf('stun') === 0) {
         iceServer = {
           'url' : url,
           'hasCredentials' : false
         };
-      } else if (url_parts[0].indexOf('turn') === 0) {
+      } else if (urlParts[0].indexOf('turn') === 0) {
         iceServer = {
           'url' : url,
           'hasCredentials' : true,


### PR DESCRIPTION
FF43+ prints warnings when the ice candidates url in in a 'url' element.
Use 'urls' instead.
Also, printing a warning when createIceServer(s) is call, notifying the user that the functions are set to be deprecated.