### PR TITLE
TWP-396: Splitting new and old constructors for RTCPeerConnection

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -916,9 +916,14 @@ if ( navigator.mozGetUserMedia
       }
 
       if (typeof constraints !== 'undefined' && constraints !== null) {
-        if (typeof constraints !== 'object' ||
-          (constraints.hasOwnProperty('mandatory') && typeof constraints.mandatory !== 'object') ||
-          (constraints.hasOwnProperty('optional')  && !Array.isArray(constraints.optional))) {
+        var invalidConstraits = false;
+        invalidConstraits |= typeof constraints !== 'object';
+        invalidConstraits |= constraints.hasOwnProperty('mandatory') && 
+                              constraints.mandatory !== null && 
+                              constraints.mandatory.constructor !== Object;
+        invalidConstraits |= constraints.hasOwnProperty('optional') && 
+                              !Array.isArray(constraints.optional);
+        if (invalidConstraits) {
           throw new Error('Failed to construct \'RTCPeerConnection\': Malformed constraints object');
         }
       }

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -907,25 +907,26 @@ if ( navigator.mozGetUserMedia
     };
 
     RTCPeerConnection = function (servers, constraints) {
-      AdapterJS.WebRTCPlugin.WaitForPluginReady();
+      if (!servers || 
+          typeof servers.iceServers !== 'object') {
+        throw new Error('new RTCPeerConnection: arg1.iceServers should be a non-null array');
+      }
 
+      AdapterJS.WebRTCPlugin.WaitForPluginReady();
       if (AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION && 
           AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION > 1) {
         // RTCPeerConnection prototype from the new spec
         return AdapterJS.WebRTCPlugin.plugin.PeerConnection(servers);
       } else {
         // RTCPeerConnection prototype from the old spec
-        var iceServers;
-        if (servers) {
-          iceServers = servers.iceServers;
-          for (var i = 0; i < iceServers.length; i++) {
-            if (iceServers[i].urls && !iceServers[i].url) {
-              iceServers[i].url = iceServers[i].urls;
-            }
-            iceServers[i].hasCredentials = AdapterJS.
-              isDefined(iceServers[i].username) &&
-              AdapterJS.isDefined(iceServers[i].credential);
+        var iceServers = servers.iceServers;
+        for (var i = 0; i < iceServers.length; i++) {
+          if (iceServers[i].urls && !iceServers[i].url) {
+            iceServers[i].url = iceServers[i].urls;
           }
+          iceServers[i].hasCredentials = AdapterJS.
+            isDefined(iceServers[i].username) &&
+            AdapterJS.isDefined(iceServers[i].credential);
         }
         var mandatory = (constraints && constraints.mandatory) ?
           constraints.mandatory : null;

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -915,6 +915,11 @@ if ( navigator.mozGetUserMedia
         throw new Error('Failed to construct \'RTCPeerConnection\': Malformed RTCConfiguration');
       }
 
+      // TODO:
+      // Mandatory constraints should be an object or null/undefined
+      // Optional constraints should be an array or not be or null/undefined
+      // Refactor
+
       var invalidConstraints = false;
 
       // Not undefined, null and [], because they are allowed

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -353,11 +353,11 @@ AdapterJS.renderNotificationBar = function (text, buttonText, buttonLink, openNe
             clearInterval(pluginInstallInterval);
             AdapterJS.WebRTCPlugin.defineWebRTCInterface();
           },
-          function() { 
+          function() {
             // still no plugin detected, nothing to do
           });
       } , 500);
-    });   
+    });
 
     // On click on Cancel
     AdapterJS.addEvent(c.document.getElementById('cancel'), 'click', function(e) {
@@ -535,8 +535,8 @@ webrtcDetectedVersion = null;
 // Check for browser types and react accordingly
 if ( navigator.mozGetUserMedia
   || navigator.webkitGetUserMedia
-  || (navigator.mediaDevices 
-    && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) ) { 
+  || (navigator.mediaDevices
+    && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) ) {
 
   ///////////////////////////////////////////////////////////////////
   // INJECTION OF GOOGLE'S ADAPTER.JS CONTENT
@@ -548,7 +548,7 @@ if ( navigator.mozGetUserMedia
 
   ///////////////////////////////////////////////////////////////////
   // EXTENSION FOR CHROME, FIREFOX AND EDGE
-  // Includes legacy functions 
+  // Includes legacy functions
   // -- createIceServer
   // -- createIceServers
   // -- MediaStreamTrack.getSources
@@ -574,7 +574,7 @@ if ( navigator.mozGetUserMedia
 
     createIceServer = function (url, username, password) {
       console.warn('createIceServer is deprecated. It should be replaced with an application level implementation.');
-      
+
       var iceServer = null;
       var url_parts = url.split(':');
       if (url_parts[0].indexOf('stun') === 0) {
@@ -616,7 +616,7 @@ if ( navigator.mozGetUserMedia
   } else if ( navigator.webkitGetUserMedia ) {
     createIceServer = function (url, username, password) {
       console.warn('createIceServer is deprecated. It should be replaced with an application level implementation.');
-      
+
       var iceServer = null;
       var url_parts = url.split(':');
       if (url_parts[0].indexOf('stun') === 0) {
@@ -668,7 +668,7 @@ if ( navigator.mozGetUserMedia
     };
   }
 
-  // Need to override attachMediaStream and reattachMediaStream 
+  // Need to override attachMediaStream and reattachMediaStream
   // to support the plugin's logic
   attachMediaStream_base = attachMediaStream;
   attachMediaStream = function (element, stream) {
@@ -907,16 +907,39 @@ if ( navigator.mozGetUserMedia
     };
 
     RTCPeerConnection = function (servers, constraints) {
-      // Throw error if servers is not either undefined, null, 
+      // Throw error if servers is not either undefined, null,
       // or with servers.iceServers being an array
-      if (!(servers === undefined || 
-            servers === null || 
+      if (!(servers === undefined ||
+            servers === null ||
             Array.isArray(servers.iceServers))) {
         throw new Error('Failed to construct \'RTCPeerConnection\': Malformed RTCConfiguration');
       }
 
+      var invalidConstraints = false;
+
+      // Not undefined, null and [], because they are allowed
+      if (typeof constraints !== 'undefined' && constraints !== null && !Array.isArray(constraints)) {
+        // Not object, incorrect
+        if (typeof constraints !== 'object') {
+          invalidConstraints = true;
+
+        } else {
+          // If optional key exists
+          if (constraints.hasOwnProperty('optional')) {
+            // Optional has to be []
+            if (!Array.isArray(constraints.optional)) {
+              invalidConstraints = true;
+            }
+          }
+        }
+      }
+
+      if (invalidConstraints) {
+        throw new Error('Failed to construct \'RTCPeerConnection\': Malformed constraints object');
+      }
+
       AdapterJS.WebRTCPlugin.WaitForPluginReady();
-      if (AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION && 
+      if (AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION &&
           AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION > 1) {
         // RTCPeerConnection prototype from the new spec
         return AdapterJS.WebRTCPlugin.plugin.PeerConnection(servers);
@@ -963,7 +986,7 @@ if ( navigator.mozGetUserMedia
     window.navigator.getUserMedia = window.getUserMedia;
 
     // Defined mediaDevices when promises are available
-    if ( !navigator.mediaDevices 
+    if ( !navigator.mediaDevices
       && typeof Promise !== 'undefined') {
       navigator.mediaDevices = {getUserMedia: requestUserMedia,
                                 enumerateDevices: function() {

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -907,21 +907,23 @@ if ( navigator.mozGetUserMedia
     };
 
     RTCPeerConnection = function (servers, constraints) {
-      // Throw error if servers is not either undefined, null,
-      // or with servers.iceServers being an array
+      // Validate server argumenr
       if (!(servers === undefined ||
             servers === null ||
             Array.isArray(servers.iceServers))) {
         throw new Error('Failed to construct \'RTCPeerConnection\': Malformed RTCConfiguration');
       }
 
+      // Validate constraints argument
       if (typeof constraints !== 'undefined' && constraints !== null) {
         var invalidConstraits = false;
         invalidConstraits |= typeof constraints !== 'object';
         invalidConstraits |= constraints.hasOwnProperty('mandatory') && 
+                              constraints.mandatory !== undefined && 
                               constraints.mandatory !== null && 
                               constraints.mandatory.constructor !== Object;
         invalidConstraits |= constraints.hasOwnProperty('optional') && 
+                              constraints.optional !== undefined &&
                               constraints.optional !== null &&
                               !Array.isArray(constraints.optional);
         if (invalidConstraits) {
@@ -929,6 +931,7 @@ if ( navigator.mozGetUserMedia
         }
       }
 
+      // Call relevant PeerConnection constructor according to plugin version
       AdapterJS.WebRTCPlugin.WaitForPluginReady();
       if (AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION &&
           AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION > 1) {

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -920,7 +920,7 @@ if ( navigator.mozGetUserMedia
       } else {
         // RTCPeerConnection prototype from the old spec
         var iceServers = null;
-        if (servers && servers.iceServers) {
+        if (servers && Array.isArray(servers.iceServers)) {
           iceServers = servers.iceServers;
           for (var i = 0; i < iceServers.length; i++) {
             if (iceServers[i].urls && !iceServers[i].url) {

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -916,18 +916,9 @@ if ( navigator.mozGetUserMedia
       }
 
       if (typeof constraints !== 'undefined' && constraints !== null) {
-        var invalidConstraints = false;
-        if (typeof constraints !== 'object') {
-          invalidConstraints = true;
-        } else if (constraints.hasOwnProperty('mandatory') &&
-          typeof constraints.mandatory !== 'object') {
-          invalidConstraints = true;
-        } else if (constraints.hasOwnProperty('optional') &&
-          !Array.isArray(constraints.optional)) {
-          invalidConstraints = true; 
-        }
-
-        if (invalidConstraints) {
+        if (typeof constraints !== 'object' ||
+          (constraints.hasOwnProperty('mandatory') && typeof constraints.mandatory !== 'object') ||
+          (constraints.hasOwnProperty('optional')  && !Array.isArray(constraints.optional))) {
           throw new Error('Failed to construct \'RTCPeerConnection\': Malformed constraints object');
         }
       }

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -907,27 +907,34 @@ if ( navigator.mozGetUserMedia
     };
 
     RTCPeerConnection = function (servers, constraints) {
-      var iceServers = null;
-      if (servers) {
-        iceServers = servers.iceServers;
-        for (var i = 0; i < iceServers.length; i++) {
-          if (iceServers[i].urls && !iceServers[i].url) {
-            iceServers[i].url = iceServers[i].urls;
-          }
-          iceServers[i].hasCredentials = AdapterJS.
-            isDefined(iceServers[i].username) &&
-            AdapterJS.isDefined(iceServers[i].credential);
-        }
-      }
-      var mandatory = (constraints && constraints.mandatory) ?
-        constraints.mandatory : null;
-      var optional = (constraints && constraints.optional) ?
-        constraints.optional : null;
-
       AdapterJS.WebRTCPlugin.WaitForPluginReady();
-      return AdapterJS.WebRTCPlugin.plugin.
-        PeerConnection(AdapterJS.WebRTCPlugin.pageId,
-        iceServers, mandatory, optional);
+
+      if (AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION && 
+          AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION > 1) {
+        // RTCPeerConnection prototype from the new spec
+        return AdapterJS.WebRTCPlugin.plugin.PeerConnection(servers);
+      } else {
+        // RTCPeerConnection prototype from the old spec
+        var iceServers;
+        if (servers) {
+          iceServers = servers.iceServers;
+          for (var i = 0; i < iceServers.length; i++) {
+            if (iceServers[i].urls && !iceServers[i].url) {
+              iceServers[i].url = iceServers[i].urls;
+            }
+            iceServers[i].hasCredentials = AdapterJS.
+              isDefined(iceServers[i].username) &&
+              AdapterJS.isDefined(iceServers[i].credential);
+          }
+        }
+        var mandatory = (constraints && constraints.mandatory) ?
+          constraints.mandatory : null;
+        var optional = (constraints && constraints.optional) ?
+          constraints.optional : null;
+        return AdapterJS.WebRTCPlugin.plugin.
+          PeerConnection(AdapterJS.WebRTCPlugin.pageId,
+          iceServers, mandatory, optional);
+      }
     };
 
     MediaStreamTrack = {};

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -915,32 +915,21 @@ if ( navigator.mozGetUserMedia
         throw new Error('Failed to construct \'RTCPeerConnection\': Malformed RTCConfiguration');
       }
 
-      // TODO:
-      // Mandatory constraints should be an object or null/undefined
-      // Optional constraints should be an array or not be or null/undefined
-      // Refactor
-
-      var invalidConstraints = false;
-
-      // Not undefined, null and [], because they are allowed
-      if (typeof constraints !== 'undefined' && constraints !== null && !Array.isArray(constraints)) {
-        // Not object, incorrect
+      if (typeof constraints !== 'undefined' && constraints !== null) {
+        var invalidConstraints = false;
         if (typeof constraints !== 'object') {
           invalidConstraints = true;
-
-        } else {
-          // If optional key exists
-          if (constraints.hasOwnProperty('optional')) {
-            // Optional has to be []
-            if (!Array.isArray(constraints.optional)) {
-              invalidConstraints = true;
-            }
-          }
+        } else if (constraints.hasOwnProperty('mandatory') &&
+          typeof constraints.mandatory !== 'object') {
+          invalidConstraints = true;
+        } else if (constraints.hasOwnProperty('optional') &&
+          !Array.isArray(constraints.optional)) {
+          invalidConstraints = true; 
         }
-      }
 
-      if (invalidConstraints) {
-        throw new Error('Failed to construct \'RTCPeerConnection\': Malformed constraints object');
+        if (invalidConstraints) {
+          throw new Error('Failed to construct \'RTCPeerConnection\': Malformed constraints object');
+        }
       }
 
       AdapterJS.WebRTCPlugin.WaitForPluginReady();

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -907,8 +907,11 @@ if ( navigator.mozGetUserMedia
     };
 
     RTCPeerConnection = function (servers, constraints) {
-      if (servers && 
-          !Array.isArray(servers.iceServers)) {
+      // Throw error if servers is not either undefined, null, 
+      // or with servers.iceServers being an array
+      if (!(servers === undefined || 
+            servers === null || 
+            Array.isArray(servers.iceServers))) {
         throw new Error('Failed to construct \'RTCPeerConnection\': Malformed RTCConfiguration');
       }
 

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -908,7 +908,7 @@ if ( navigator.mozGetUserMedia
 
     RTCPeerConnection = function (servers, constraints) {
       if (servers && 
-          typeof servers.iceServers !== 'object') {
+          !Array.isArray(servers.iceServers)) {
         throw new Error('Failed to construct \'RTCPeerConnection\': Malformed RTCConfiguration');
       }
 
@@ -919,14 +919,17 @@ if ( navigator.mozGetUserMedia
         return AdapterJS.WebRTCPlugin.plugin.PeerConnection(servers);
       } else {
         // RTCPeerConnection prototype from the old spec
-        var iceServers = servers.iceServers;
-        for (var i = 0; i < iceServers.length; i++) {
-          if (iceServers[i].urls && !iceServers[i].url) {
-            iceServers[i].url = iceServers[i].urls;
+        var iceServers = null;
+        if (servers && servers.iceServers) {
+          iceServers = servers.iceServers;
+          for (var i = 0; i < iceServers.length; i++) {
+            if (iceServers[i].urls && !iceServers[i].url) {
+              iceServers[i].url = iceServers[i].urls;
+            }
+            iceServers[i].hasCredentials = AdapterJS.
+              isDefined(iceServers[i].username) &&
+              AdapterJS.isDefined(iceServers[i].credential);
           }
-          iceServers[i].hasCredentials = AdapterJS.
-            isDefined(iceServers[i].username) &&
-            AdapterJS.isDefined(iceServers[i].credential);
         }
         var mandatory = (constraints && constraints.mandatory) ?
           constraints.mandatory : null;

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -907,9 +907,9 @@ if ( navigator.mozGetUserMedia
     };
 
     RTCPeerConnection = function (servers, constraints) {
-      if (!servers || 
+      if (servers && 
           typeof servers.iceServers !== 'object') {
-        throw new Error('new RTCPeerConnection: arg1.iceServers should be a non-null array');
+        throw new Error('Failed to construct \'RTCPeerConnection\': Malformed RTCConfiguration');
       }
 
       AdapterJS.WebRTCPlugin.WaitForPluginReady();

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -922,6 +922,7 @@ if ( navigator.mozGetUserMedia
                               constraints.mandatory !== null && 
                               constraints.mandatory.constructor !== Object;
         invalidConstraits |= constraints.hasOwnProperty('optional') && 
+                              constraints.optional !== null &&
                               !Array.isArray(constraints.optional);
         if (invalidConstraits) {
           throw new Error('Failed to construct \'RTCPeerConnection\': Malformed constraints object');

--- a/tests/unit/RTCPeerConnection.constraints.spec.js
+++ b/tests/unit/RTCPeerConnection.constraints.spec.js
@@ -94,9 +94,12 @@ describe('RTCPeerConnection | RTCConfiguration', function() {
   testRTCPCContruct({ iceServers: [{ url: 'stun:stun.l.google.com:19302' }] });
   testRTCPCContruct({ iceServers: [{ url: 'turn:numb.viagenie.ca', username: 'leticia.choo@temasys.com.sg', credential: 'xxxxx' }, { url: 'stun:stun.l.google.com:19302' }] });
   testRTCPCContruct({ iceServers: [] }, { optional: [{ DtlsSrtpKeyAgreement: true }] });
+  testRTCPCContruct({ iceServers: [] }, {});
   testRTCPCContruct({ iceServers: [] }, { optional: [] });
+  testRTCPCContruct({ iceServers: [] }, { optional: undefined });
   testRTCPCContruct({ iceServers: [] }, { optional: null });
   testRTCPCContruct({ iceServers: [] }, { mandatory: {} });
+  testRTCPCContruct({ iceServers: [] }, { mandatory: undefined });
   testRTCPCContruct({ iceServers: [] }, { mandatory: null });
   testRTCPCContruct({ iceServers: [] }, { optional: [], mandatory: {} });
   testRTCPCContruct({ iceServers: [] }, { optional: [], mandatory: null });
@@ -126,7 +129,6 @@ describe('RTCPeerConnection | RTCConfiguration', function() {
   testRTCPCContruct_throw({ iceServers: [] }, { mandatory: 'test'});
   testRTCPCContruct_throw({ iceServers: [] }, { mandatory: 1 });
   testRTCPCContruct_throw({ iceServers: [] }, { mandatory: 0 });
-  testRTCPCContruct_throw({ iceServers: [] }, { mandatory: undefined });
   testRTCPCContruct_throw({ iceServers: [] }, { optional: 'test', mandatory: [] });
   testRTCPCContruct_throw({ iceServers: [] }, { optional: [], mandatory: 'test' });
 

--- a/tests/unit/RTCPeerConnection.constraints.spec.js
+++ b/tests/unit/RTCPeerConnection.constraints.spec.js
@@ -95,6 +95,7 @@ describe('RTCPeerConnection | RTCConfiguration', function() {
   testRTCPCContruct({ iceServers: [{ url: 'turn:numb.viagenie.ca', username: 'leticia.choo@temasys.com.sg', credential: 'xxxxx' }, { url: 'stun:stun.l.google.com:19302' }] });
   testRTCPCContruct({ iceServers: [] }, { optional: [{ DtlsSrtpKeyAgreement: true }] });
   testRTCPCContruct({ iceServers: [] }, { optional: [] });
+  testRTCPCContruct({ iceServers: [] }, { optional: null });
   testRTCPCContruct({ iceServers: [] }, { mandatory: {} });
   testRTCPCContruct({ iceServers: [] }, { mandatory: null });
   testRTCPCContruct({ iceServers: [] }, { optional: [], mandatory: {} });
@@ -117,7 +118,6 @@ describe('RTCPeerConnection | RTCConfiguration', function() {
   testRTCPCContruct_throw(null, 'test');
   testRTCPCContruct_throw(null, { optional: 1 });
   testRTCPCContruct_throw(null, { optional: 0 });
-  testRTCPCContruct_throw(null, { optional: null });
   testRTCPCContruct_throw(null, { optional: 'test' });
   testRTCPCContruct_throw(null, { optional: true });
   testRTCPCContruct_throw(null, { optional: false });

--- a/tests/unit/RTCPeerConnection.constraints.spec.js
+++ b/tests/unit/RTCPeerConnection.constraints.spec.js
@@ -27,121 +27,77 @@ describe('RTCPeerConnection | RTCConfiguration', function() {
     });
   });
 
-  (function (constraints) {
+  var makeDesc = function (config, constraints) {
+    var description = 'new RTCPeerConnection(';
+    if (config !== undefined) {
+      description += JSON.stringify(config);
+    }
+    if (constraints !== undefined) {
+      description += ', ' + JSON.stringify(constraints);
+    }
+    description += ')';
 
-    it('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {
+    return description;
+  };
+
+  var testRTCPCContruct = function (config, constraints) {
+    var description = makeDesc(config, constraints);
+    it(description, function () {
       this.timeout(testItemTimeout);
 
-      var peer = new RTCPeerConnection(constraints);
+      var peer = new RTCPeerConnection(config, constraints);
     });
+  };
 
-  })({ iceServers: [] });
-
-
-  (function (constraints) {
-
-    it('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {
+  var testRTCPCContruct_skip = function (config, constraints) {
+    var description = makeDesc(config, constraints);
+    it.skip(description, function () {
       this.timeout(testItemTimeout);
 
-      var peer = new RTCPeerConnection(constraints);
+      var peer = new RTCPeerConnection(config, constraints);
     });
+  };
 
-  })({ iceServers: [{ url: 'turn:numb.viagenie.ca', username: 'leticia.choo@temasys.com.sg', credential: 'xxxxx' }] });
-
-
-  (function (constraints) {
-
-    it('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {
+  var testRTCPCContruct_throw = function (config, constraints) {
+    var description = makeDesc(config, constraints);
+    description += ' -> Throws Error';
+    it(description, function () {
       this.timeout(testItemTimeout);
 
-      var peer = new RTCPeerConnection(constraints);
+      var fn = function() {
+        var peer = new RTCPeerConnection(config, constraints);
+      };
+
+      expect(fn).to.throw(Error);
     });
+  };
 
-  })({ iceServers: [{ url: 'leticia.choo@temasys.com.sg@turn:numb.viagenie.ca', credential: 'xxxxx' }] });
+  // EXPECT WORKING
+  testRTCPCContruct();
+  testRTCPCContruct(null);
+  testRTCPCContruct(null, {});
+  testRTCPCContruct(null, null);
+  testRTCPCContruct(null, null, null);
+  testRTCPCContruct({ iceServers: [] });
+  testRTCPCContruct({ iceServers: [{ url: 'turn:numb.viagenie.ca', username: 'leticia.choo@temasys.com.sg', credential: 'xxxxx' }] });
+  testRTCPCContruct({ iceServers: [{ url: 'leticia.choo@temasys.com.sg@turn:numb.viagenie.ca', credential: 'xxxxx' }] });
+  testRTCPCContruct({ iceServers: [{ urls: ['turn:numb.viagenie.ca', 'turn:numb.viagenie.ca'], username: 'leticia.choo@temasys.com.sg', credential: 'xxxxx' }] });
+  testRTCPCContruct({ iceServers: [{ url: 'stun:stun.l.google.com:19302' }] });
+  testRTCPCContruct({ iceServers: [{ url: 'turn:numb.viagenie.ca', username: 'leticia.choo@temasys.com.sg', credential: 'xxxxx' }, { url: 'stun:stun.l.google.com:19302' }] });
+  testRTCPCContruct({ iceServers: [] }, { optional: [{ DtlsSrtpKeyAgreement: true }] });
 
+  // EXPECT THROWNIG ERROR
+  testRTCPCContruct_throw({});
+  testRTCPCContruct_throw({ iceServers: null });
+  testRTCPCContruct_throw({ iceServers: '' });
+  testRTCPCContruct_throw({ iceServers: true });
 
-  (function (constraints) {
+  // SKIP TEST
+  testRTCPCContruct_skip({ bundlePolicy: 'balanced' });
+  testRTCPCContruct_skip({ bundlePolicy: 'max-compat' });
+  testRTCPCContruct_skip({ bundlePolicy: 'max-bundle' });
+  testRTCPCContruct_skip({ iceTransportPolicy: 'none' });
+  testRTCPCContruct_skip({ iceTransportPolicy: 'relay' });
+  testRTCPCContruct_skip({ iceTransportPolicy: 'all' });
 
-    it('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {
-      this.timeout(testItemTimeout);
-
-      var peer = new RTCPeerConnection(constraints);
-    });
-
-  })({ iceServers: [{ urls: ['turn:numb.viagenie.ca', 'turn:numb.viagenie.ca'], username: 'leticia.choo@temasys.com.sg', credential: 'xxxxx' }] });
-
-
-  (function (constraints) {
-
-    it('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {
-      this.timeout(testItemTimeout);
-
-      var peer = new RTCPeerConnection(constraints);
-    });
-
-  })({ iceServers: [{ url: 'stun:stun.l.google.com:19302' }] });
-
-
-  (function (constraints) {
-
-    it('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {
-      this.timeout(testItemTimeout);
-
-      var peer = new RTCPeerConnection(constraints);
-    });
-
-  })({ iceServers: [{ url: 'turn:numb.viagenie.ca', username: 'leticia.choo@temasys.com.sg', credential: 'xxxxx' }, { url: 'stun:stun.l.google.com:19302' }] });
-
-
-  (function (constraints) {
-
-    it.skip('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {});
-
-  })({ bundlePolicy: 'balanced' });
-
-
-  (function (constraints) {
-
-    it.skip('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {});
-
-  })({ bundlePolicy: 'max-compat' });
-
-
-  (function (constraints) {
-
-    it.skip('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {});
-
-  })({ bundlePolicy: 'max-bundle' });
-
-
-  (function (constraints) {
-
-    it.skip('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {});
-
-  })({ iceTransportPolicy: 'none' });
-
-
-  (function (constraints) {
-
-    it.skip('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {});
-
-  })({ iceTransportPolicy: 'relay' });
-
-
-  (function (constraints) {
-
-    it.skip('new RTCPeerConnection(' + JSON.stringify(constraints) + ')', function () {});
-
-  })({ iceTransportPolicy: 'all' });
-
-
-  (function (constraints, optional) {
-
-    it('new RTCPeerConnection(' + JSON.stringify(constraints) + ', ' + JSON.stringify(optional) + ')', function () {
-      this.timeout(testItemTimeout);
-
-      var peer = new RTCPeerConnection(constraints, optional);
-    });
-
-  })({ iceServers: [] }, { optional: [{ DtlsSrtpKeyAgreement: true }] });
 });

--- a/tests/unit/RTCPeerConnection.constraints.spec.js
+++ b/tests/unit/RTCPeerConnection.constraints.spec.js
@@ -95,6 +95,10 @@ describe('RTCPeerConnection | RTCConfiguration', function() {
   testRTCPCContruct({ iceServers: [{ url: 'turn:numb.viagenie.ca', username: 'leticia.choo@temasys.com.sg', credential: 'xxxxx' }, { url: 'stun:stun.l.google.com:19302' }] });
   testRTCPCContruct({ iceServers: [] }, { optional: [{ DtlsSrtpKeyAgreement: true }] });
   testRTCPCContruct({ iceServers: [] }, { optional: [] });
+  testRTCPCContruct({ iceServers: [] }, { mandatory: {} });
+  testRTCPCContruct({ iceServers: [] }, { mandatory: null });
+  testRTCPCContruct({ iceServers: [] }, { optional: [], mandatory: {} });
+  testRTCPCContruct({ iceServers: [] }, { optional: [], mandatory: null });
 
   // EXPECT THROWNIG ERROR
   testRTCPCContruct_throw(1);
@@ -118,6 +122,13 @@ describe('RTCPeerConnection | RTCConfiguration', function() {
   testRTCPCContruct_throw(null, { optional: true });
   testRTCPCContruct_throw(null, { optional: false });
   testRTCPCContruct_throw(null, { optional: {} }); // Should throw error as there are plugin failures
+  testRTCPCContruct_throw({ iceServers: [] }, { mandatory: [] });
+  testRTCPCContruct_throw({ iceServers: [] }, { mandatory: 'test'});
+  testRTCPCContruct_throw({ iceServers: [] }, { mandatory: 1 });
+  testRTCPCContruct_throw({ iceServers: [] }, { mandatory: 0 });
+  testRTCPCContruct_throw({ iceServers: [] }, { mandatory: undefined });
+  testRTCPCContruct_throw({ iceServers: [] }, { optional: 'test', mandatory: [] });
+  testRTCPCContruct_throw({ iceServers: [] }, { optional: [], mandatory: 'test' });
 
   // SKIP TEST
   testRTCPCContruct_skip({ bundlePolicy: 'balanced' });

--- a/tests/unit/RTCPeerConnection.constraints.spec.js
+++ b/tests/unit/RTCPeerConnection.constraints.spec.js
@@ -75,9 +75,18 @@ describe('RTCPeerConnection | RTCConfiguration', function() {
   // EXPECT WORKING
   testRTCPCContruct();
   testRTCPCContruct(null);
+  testRTCPCContruct(null, []);
   testRTCPCContruct(null, {});
   testRTCPCContruct(null, null);
   testRTCPCContruct(null, null, null);
+  testRTCPCContruct(null, null, 0);
+  testRTCPCContruct(null, null, 1);
+  testRTCPCContruct(null, null, true);
+  testRTCPCContruct(null, null, false);
+  testRTCPCContruct(null, null, 'test');
+  testRTCPCContruct(null, null, {});
+  testRTCPCContruct(null, null, []);
+  testRTCPCContruct(null, null, { test: [] });
   testRTCPCContruct({ iceServers: [] });
   testRTCPCContruct({ iceServers: [{ url: 'turn:numb.viagenie.ca', username: 'leticia.choo@temasys.com.sg', credential: 'xxxxx' }] });
   testRTCPCContruct({ iceServers: [{ url: 'leticia.choo@temasys.com.sg@turn:numb.viagenie.ca', credential: 'xxxxx' }] });
@@ -85,12 +94,30 @@ describe('RTCPeerConnection | RTCConfiguration', function() {
   testRTCPCContruct({ iceServers: [{ url: 'stun:stun.l.google.com:19302' }] });
   testRTCPCContruct({ iceServers: [{ url: 'turn:numb.viagenie.ca', username: 'leticia.choo@temasys.com.sg', credential: 'xxxxx' }, { url: 'stun:stun.l.google.com:19302' }] });
   testRTCPCContruct({ iceServers: [] }, { optional: [{ DtlsSrtpKeyAgreement: true }] });
+  testRTCPCContruct({ iceServers: [] }, { optional: [] });
 
   // EXPECT THROWNIG ERROR
+  testRTCPCContruct_throw(1);
+  testRTCPCContruct_throw(0);
+  testRTCPCContruct_throw(true);
+  testRTCPCContruct_throw(false);
+  testRTCPCContruct_throw('test');
   testRTCPCContruct_throw({});
   testRTCPCContruct_throw({ iceServers: null });
   testRTCPCContruct_throw({ iceServers: '' });
   testRTCPCContruct_throw({ iceServers: true });
+  testRTCPCContruct_throw(null, 1);
+  testRTCPCContruct_throw(null, 0);
+  testRTCPCContruct_throw(null, true);
+  testRTCPCContruct_throw(null, false);
+  testRTCPCContruct_throw(null, 'test');
+  testRTCPCContruct_throw(null, { optional: 1 });
+  testRTCPCContruct_throw(null, { optional: 0 });
+  testRTCPCContruct_throw(null, { optional: null });
+  testRTCPCContruct_throw(null, { optional: 'test' });
+  testRTCPCContruct_throw(null, { optional: true });
+  testRTCPCContruct_throw(null, { optional: false });
+  testRTCPCContruct_throw(null, { optional: {} }); // Should throw error as there are plugin failures
 
   // SKIP TEST
   testRTCPCContruct_skip({ bundlePolicy: 'balanced' });


### PR DESCRIPTION
The next plugin version supports a new constructor more in line with the specs
https://www.w3.org/TR/webrtc/#widl-ctor-RTCPeerConnection--RTCConfiguration-configuration

This 
* calls the new constructor if it is available, 
* call the previous constructor otherwise