### PR TITLE
Fixing screensharing-gum link in Chrome

### DIFF
--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -149,6 +149,7 @@
     };
 
     getUserMedia = navigator.getUserMedia;
+    navigator.mediaDevices.getUserMedia = requestUserMedia;
 
   } else if (navigator.mediaDevices && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) {
     // nothing here because edge does not support screensharing

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -69,6 +69,7 @@
     };
 
     getUserMedia = navigator.getUserMedia;
+    navigator.mediaDevices.getUserMedia = requestUserMedia;
 
   } else if (window.navigator.webkitGetUserMedia) {
     baseGetUserMedia = window.navigator.getUserMedia;
@@ -187,6 +188,7 @@
     };
 
     getUserMedia = window.navigator.getUserMedia;
+    navigator.mediaDevices.getUserMedia = requestUserMedia;
   }
 
   // For chrome, use an iframe to load the screensharing extension


### PR DESCRIPTION
With the screensharing AJS, Chrome currently takes a screensharing request as a camera request.
Seems to be due to a bad gum link.

This should fix it.