### PR TITLE
Fixes for Firefox screensharing addon

### DIFF
--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -51,7 +51,7 @@
             clearInterval(checkIfReady);
 
             baseGetUserMedia(updatedConstraints, successCb, function (error) {
-              if (error.name === 'PermissionDeniedError' && window.parent.location.protocol === 'https:') {
+              if (['PermissionDeniedError', 'SecurityError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
                 AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_FF,
                   AdapterJS.TEXT.EXTENSION.BUTTON_FF,
                   'http://skylink.io/screensharing/ff_addon.php?domain=' + window.location.hostname, false, true);

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -54,8 +54,7 @@
               if (['PermissionDeniedError', 'SecurityError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
                 AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_FF,
                   AdapterJS.TEXT.EXTENSION.BUTTON_FF,
-                  'http://skylink.io/screensharing/ff_addon.php?domain=' + window.location.hostname, false, true);
-                //window.location.href = 'http://skylink.io/screensharing/ff_addon.php?domain=' + window.location.hostname;
+                  'https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/', true, true);
               } else {
                 failureCb(error);
               }


### PR DESCRIPTION
This PR commits should:
- Fix the prompt that is not prompting
- Removal of the auto-generation of Firefox extension link and link to a default Skylink extension link. This might take about 10days for full-review to be verified, but link is still the same and usable.