### PR TITLE
Fix getUserMedia when not imported in global scope (ex. via webpack)

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -658,7 +658,7 @@ if ( navigator.mozGetUserMedia
   // attachMediaStream and reattachMediaStream for Egde
   if (navigator.mediaDevices && navigator.userAgent.match(
       /Edge\/(\d+).(\d+)$/)) {
-    window.getUserMedia = navigator.getUserMedia.bind(navigator);
+    getUserMedia = window.getUserMedia = navigator.getUserMedia.bind(navigator);
     attachMediaStream = function(element, stream) {
       element.srcObject = stream;
       return element;
@@ -938,7 +938,7 @@ if ( navigator.mozGetUserMedia
       });
     };
 
-    window.getUserMedia = function (constraints, successCallback, failureCallback) {
+    getUserMedia = window.getUserMedia = function (constraints, successCallback, failureCallback) {
       constraints.audio = constraints.audio || false;
       constraints.video = constraints.video || false;
 


### PR DESCRIPTION
When imported in global scope (say, directly in a script tag), the existing code works fine because `window.getUserMedia = ...` also assigns to the `getUserMedia` variable declared as part of the included google adapter.js code.

However, when the code isn't imported in global scope (for example, if it's included via webpack - where it's evaluated inside a function), `window.getUserMedia` and `getUserMedia` are actually two different variables.  This causes `requestUserMedia` (defined in the google adapter.js code) to fail when it tries to read the local `getUserMedia` variable, which will be null at this point.

I have another branch where I manually updated `publish/adapter.debug.js` file, if I should also include those updates in this PR (I need it to be able to import it via npm).  Just rebuilding (`grunt publish`) doesn't seem to work, since it ends up removing the google adapter.js code.  I'm not sure what to do about that.