### PR TITLE
Fix getUserMedia when not imported in global scope (ex. via webpack)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -293,6 +293,12 @@ module.exports = function(grunt) {
         grunt.log.writeln('bamboo/vars file successfully created');
     });
 
+    grunt.registerTask('CheckSubmodules', 'Checks that third_party/adapter is properly checked out', function() {
+      if(!grunt.file.exists(grunt.config.get('googleAdapterPath'))) {
+        grunt.fail.fatal("Couldn't find " + grunt.config.get('googleAdapterPath') + "; output would be incomplete.  Did you remember to initialize submodules?\nex: git submodule update --init");
+      }
+    });
+
     grunt.registerTask('CheckPluginInfo', 'Checks for existing config file', function() {
       var fullPath = grunt.config.get('pluginInfoRoot') + '/' + grunt.config.get('pluginInfoFile');
       grunt.verbose.writeln('Checking that the plugin info file exists.');
@@ -319,6 +325,7 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask('publish', [
+        'CheckSubmodules',
         'CheckPluginInfo',
         // 'webrtc-adapter',
         'versionise',

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -658,7 +658,7 @@ if ( navigator.mozGetUserMedia ||
   // attachMediaStream and reattachMediaStream for Egde
   if (navigator.mediaDevices && navigator.userAgent.match(
       /Edge\/(\d+).(\d+)$/)) {
-    window.getUserMedia = navigator.getUserMedia.bind(navigator);
+    getUserMedia = window.getUserMedia = navigator.getUserMedia.bind(navigator);
     attachMediaStream = function(element, stream) {
       element.srcObject = stream;
       return element;
@@ -974,7 +974,7 @@ if ( navigator.mozGetUserMedia ||
       });
     };
 
-    window.getUserMedia = function (constraints, successCallback, failureCallback) {
+    getUserMedia = window.getUserMedia = function (constraints, successCallback, failureCallback) {
       constraints.audio = constraints.audio || false;
       constraints.video = constraints.video || false;
 


### PR DESCRIPTION
When imported in global scope (say, directly in a script tag), the existing code works fine because `window.getUserMedia = ...` also assigns to the `getUserMedia` variable declared as part of the included google adapter.js code.

However, when the code isn't imported in global scope (for example, if it's included via webpack - where it's evaluated inside a function), `window.getUserMedia` and `getUserMedia` are actually two different variables.  This causes `requestUserMedia` (defined in the google adapter.js code) to fail when it tries to read the local `getUserMedia` variable, which will be null at this point.

I can add a commit to update the stuff in `publish` (calling `grunt publish` after initializing the submodule), if you want.