### PR TITLE
TWP-328 Forward all properties of video element to the plugin object

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1118,6 +1118,12 @@ if ( navigator.mozGetUserMedia ||
     AdapterJS.reattachMediaStream = reattachMediaStream;
 
     AdapterJS.forwardEventHandlers = function (destElem, srcElem, prototype) {
+      for (var property in srcElem) {
+        if (srcElem.hasOwnProperty(property)) {
+          destElem[property] = srcElem[property];
+        }
+      }
+
       properties = Object.getOwnPropertyNames( prototype );
       for(var prop in properties) {
         if (prop) {
@@ -1131,8 +1137,7 @@ if ( navigator.mozGetUserMedia ||
                 destElem.addEventListener(propName.slice(2), srcElem[propName], false);
               }
             }
-            //TODO (http://jira.temasys.com.sg/browse/TWP-328) Forward non-event properties ?
-          }
+          } 
         }
       }
       var subPrototype = Object.getPrototypeOf(prototype);

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1088,7 +1088,7 @@ if ( navigator.mozGetUserMedia ||
         element.setStreamId(streamId);
       }
       var newElement = document.getElementById(elementId);
-      AdapterJS.forwardEventHandlers(newElement, element, Object.getPrototypeOf(element));
+      AdapterJS.forwardAttributesAndEvents(newElement, element, Object.getPrototypeOf(element));
 
       return newElement;
     };
@@ -1117,7 +1117,7 @@ if ( navigator.mozGetUserMedia ||
     AdapterJS.attachMediaStream   = attachMediaStream;
     AdapterJS.reattachMediaStream = reattachMediaStream;
 
-    AdapterJS.forwardEventHandlers = function (destElem, srcElem, prototype) {
+    AdapterJS.forwardAttributesAndEvents = function (destElem, srcElem, prototype) {
       for (var property in srcElem) {
         if (srcElem.hasOwnProperty(property)) {
           destElem[property] = srcElem[property];
@@ -1142,7 +1142,7 @@ if ( navigator.mozGetUserMedia ||
       }
       var subPrototype = Object.getPrototypeOf(prototype);
       if(!!subPrototype) {
-        AdapterJS.forwardEventHandlers(destElem, srcElem, subPrototype);
+        AdapterJS.forwardAttributesAndEvents(destElem, srcElem, subPrototype);
       }
     };
 


### PR DESCRIPTION
Rebased and corrected Seb's branch
- forward attributes to the plugin
- concerns only the plugin (IE/Safari), not Chrome and FF

How to test:
* have a <video> element
* set it with a few attributes
* call gUM and `video = attachMediaStream(video, stream)`
* test that the new video element has the same attributes as the original one