### PR TITLE
github#177 special case for attachMediaStream on Chrome when no stream

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -673,7 +673,12 @@ if ( navigator.mozGetUserMedia ||
   // to support the plugin's logic
   attachMediaStream_base = attachMediaStream;
   attachMediaStream = function (element, stream) {
-    attachMediaStream_base(element, stream);
+    if (webrtcDetectedBrowser === 'chrome' && !stream) {
+      // Chrome does not support "src = null"
+      element.src = '';
+    } else {
+      attachMediaStream_base(element, stream);
+    }
     return element;
   };
   reattachMediaStream_base = reattachMediaStream;

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1134,15 +1134,10 @@ if ( navigator.mozGetUserMedia ||
         if (prop) {
           propName = properties[prop];
 
-          if (typeof(propName.slice) === 'function') {
-            if (propName.slice(0,2) === 'on' && srcElem[propName] !== null) {
-              if (isIE) {
-                destElem.attachEvent(propName,srcElem[propName]);
-              } else {
-                destElem.addEventListener(propName.slice(2), srcElem[propName], false);
-              }
-            }
-            //TODO (http://jira.temasys.com.sg/browse/TWP-328) Forward non-event properties ?
+          if (typeof propName.slice === 'function' &&
+              propName.slice(0,2) === 'on' && 
+              typeof srcElem[propName] === 'function') {
+              AdapterJS.addEvent(destElem, propName.slice(2), srcElem[propName]);
           }
         }
       }

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -673,7 +673,9 @@ if ( navigator.mozGetUserMedia ||
   // to support the plugin's logic
   attachMediaStream_base = attachMediaStream;
   attachMediaStream = function (element, stream) {
-    if (webrtcDetectedBrowser === 'chrome' && !stream) {
+    if ((webrtcDetectedBrowser === 'chrome' ||
+         webrtcDetectedBrowser === 'opera') && 
+        !stream) {
       // Chrome does not support "src = null"
       element.src = '';
     } else {


### PR DESCRIPTION
In answer of https://github.com/Temasys/AdapterJS/issues/177 .

Setting `srcObject` to `null` on a video object generates an error on Chrome.
Create a special case for Chrome where we set it to an empty string instead.