### PR TITLE
AJS-253: Fixes for undefined webrtcDetectedBrowser, webrtcDetectedVersion and webrtcMinimumVersion using browserify

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -275,6 +275,10 @@ AdapterJS.parseWebrtcDetectedBrowser = function () {
     webrtcDetectedBrowser = 'blink';
     // TODO: detected WebRTC version
   }
+
+  window.webrtcDetectedBrowser = webrtcDetectedBrowser;
+  window.webrtcDetectedVersion = webrtcDetectedVersion;
+  window.webrtcMinimumVersion  = webrtcMinimumVersion;
 };
 
 AdapterJS.addEvent = function(elem, evnt, func) {
@@ -1205,7 +1209,3 @@ if ( navigator.mozGetUserMedia ||
   // END OF WEBRTC PLUGIN SHIM
   ///////////////////////////////////////////////////////////////////
 }
-
-window.webrtcDetectedBrowser = webrtcDetectedBrowser;
-window.webrtcDetectedVersion = webrtcDetectedVersion;
-window.webrtcMinimumVersion = webrtcMinimumVersion;

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1205,3 +1205,7 @@ if ( navigator.mozGetUserMedia ||
   // END OF WEBRTC PLUGIN SHIM
   ///////////////////////////////////////////////////////////////////
 }
+
+window.webrtcDetectedBrowser = webrtcDetectedBrowser;
+window.webrtcDetectedVersion = webrtcDetectedVersion;
+window.webrtcMinimumVersion = webrtcMinimumVersion;


### PR DESCRIPTION
Tested in `http:` protocol environment compiled with browserify using SkylinkJS test scripts compilation.

I followed the logic @johache had to resolve PR #173 fixes.

----

#### Testing in adapter.debug.js file
**(PASS) Firefox 45**
- `webrtcDetectedBrowser` -> `"firefox"`
- `webrtcDetectedVersion` -> `45`
- `webrtcMinimumVersion` -> `31`

**(PASS) Chrome 49**
- `webrtcDetectedBrowser` -> `"chrome"`
- `webrtcDetectedVersion` -> `49`
- `webrtcMinimumVersion` -> `38`

**(PASS) Safari 8.0.6**
- `webrtcDetectedBrowser` -> `"safari"`
- `webrtcDetectedVersion` -> `8`
- `webrtcMinimumVersion` -> `7`

**(PASS) Opera 35**
- `webrtcDetectedBrowser` -> `"opera"`
- `webrtcDetectedVersion` -> `35`
- `webrtcMinimumVersion` -> `26`

#### Testing in adapter.screenshare.js file
**(PASS) Firefox 45**
- `webrtcDetectedBrowser` -> `"firefox"`
- `webrtcDetectedVersion` -> `45`
- `webrtcMinimumVersion` -> `31`
- Screensharing - Throws `SecurityError` as not in `https:` protocol environment.

**(PASS) Chrome 49**
- `webrtcDetectedBrowser` -> `"chrome"`
- `webrtcDetectedVersion` -> `49`
- `webrtcMinimumVersion` -> `38`
- Screensharing - Retrieves screen and throws `PermissionDeniedError` for retrieval of audio as not in `https:` protocol environment.

**(PASS) Opera 35**
- `webrtcDetectedBrowser` -> `"opera"`
- `webrtcDetectedVersion` -> `35`
- `webrtcMinimumVersion` -> `26`
- Screensharing - Throws `Error` that current browser does not support screensharing because I am not using a commercial plugin.

**(PASS) Safari 8.0.6**
- `webrtcDetectedBrowser` -> `"safari"`
- `webrtcDetectedVersion` -> `8`
- `webrtcMinimumVersion` -> `7`
- Screensharing - Throws `Error` that current plugin does not support screensharing