### PR TITLE
AJS-257: Fixes to ensure that navigator.mediaDevices is always defined.

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -760,6 +760,11 @@ if ( navigator.mozGetUserMedia ||
   AdapterJS.parseWebrtcDetectedBrowser();
   isIE = webrtcDetectedBrowser === 'IE';
 
+  // always define navigator.mediaDevices if it's not defined
+  if (!navigator.mediaDevices) {
+    navigator.mediaDevices = {};
+  }
+
   /* jshint -W035 */
   AdapterJS.WebRTCPlugin.WaitForPluginReady = function() {
     while (AdapterJS.WebRTCPlugin.pluginState !== AdapterJS.WebRTCPlugin.PLUGIN_STATES.READY) {
@@ -999,8 +1004,7 @@ if ( navigator.mozGetUserMedia ||
     window.navigator.getUserMedia = getUserMedia;
 
     // Defined mediaDevices when promises are available
-    if ( !navigator.mediaDevices &&
-      typeof Promise !== 'undefined') {
+    if (typeof Promise !== 'undefined') {
       requestUserMedia = function(constraints) {
         return new Promise(function(resolve, reject) {
           getUserMedia(constraints, resolve, reject);

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -760,11 +760,6 @@ if ( navigator.mozGetUserMedia ||
   AdapterJS.parseWebrtcDetectedBrowser();
   isIE = webrtcDetectedBrowser === 'IE';
 
-  // always define navigator.mediaDevices if it's not defined
-  if (!navigator.mediaDevices) {
-    navigator.mediaDevices = {};
-  }
-
   /* jshint -W035 */
   AdapterJS.WebRTCPlugin.WaitForPluginReady = function() {
     while (AdapterJS.WebRTCPlugin.pluginState !== AdapterJS.WebRTCPlugin.PLUGIN_STATES.READY) {
@@ -1004,7 +999,8 @@ if ( navigator.mozGetUserMedia ||
     window.navigator.getUserMedia = getUserMedia;
 
     // Defined mediaDevices when promises are available
-    if (typeof Promise !== 'undefined') {
+    if ( !navigator.mediaDevices &&
+      typeof Promise !== 'undefined') {
       requestUserMedia = function(constraints) {
         return new Promise(function(resolve, reject) {
           getUserMedia(constraints, resolve, reject);

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -196,7 +196,10 @@
 
     AdapterJS.getUserMedia = getUserMedia = 
        window.getUserMedia = navigator.getUserMedia;
-    navigator.mediaDevices.getUserMedia = requestUserMedia;
+    if ( navigator.mediaDevices &&
+      typeof Promise !== 'undefined') {
+      navigator.mediaDevices.getUserMedia = requestUserMedia;
+    }
   }
 
   // For chrome, use an iframe to load the screensharing extension


### PR DESCRIPTION
Re-opened from #184 due to incorrect branch.

----

This should fix the issue in IE browsers that navigator.mediaDevices is not defined.

See JIRA Ticket - [AJS-257](http://jira.temasys.com.sg/browse/AJS-257)