### PR TITLE
TWP-443: Fixes to ensure "relay" candidates are returned if TURN credentials are provided

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -959,6 +959,7 @@ if ( navigator.mozGetUserMedia ||
       if (servers && Array.isArray(servers.iceServers)) {
         iceServers = servers.iceServers;
         for (var i = 0; i < iceServers.length; i++) {
+          // Legacy plugin versions compatibility
           if (iceServers[i].urls && !iceServers[i].url) {
             iceServers[i].url = iceServers[i].urls;
           }
@@ -971,10 +972,8 @@ if ( navigator.mozGetUserMedia ||
       if (AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION &&
           AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION > 1) {
         // RTCPeerConnection prototype from the new spec
-        if (iceServers) {
-          servers.iceServers = iceServers;
-        }
-        return AdapterJS.WebRTCPlugin.plugin.PeerConnection(servers);
+        var s = { iceServers: iceServers };
+        return AdapterJS.WebRTCPlugin.plugin.PeerConnection(s);
       } else {
         var mandatory = (constraints && constraints.mandatory) ?
           constraints.mandatory : null;

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -953,24 +953,29 @@ if ( navigator.mozGetUserMedia ||
 
       // Call relevant PeerConnection constructor according to plugin version
       AdapterJS.WebRTCPlugin.WaitForPluginReady();
+
+      // RTCPeerConnection prototype from the old spec
+      var iceServers = null;
+      if (servers && Array.isArray(servers.iceServers)) {
+        iceServers = servers.iceServers;
+        for (var i = 0; i < iceServers.length; i++) {
+          if (iceServers[i].urls && !iceServers[i].url) {
+            iceServers[i].url = iceServers[i].urls;
+          }
+          iceServers[i].hasCredentials = AdapterJS.
+            isDefined(iceServers[i].username) &&
+            AdapterJS.isDefined(iceServers[i].credential);
+        }
+      }
+
       if (AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION &&
           AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION > 1) {
         // RTCPeerConnection prototype from the new spec
+        if (iceServers) {
+          servers.iceServers = iceServers;
+        }
         return AdapterJS.WebRTCPlugin.plugin.PeerConnection(servers);
       } else {
-        // RTCPeerConnection prototype from the old spec
-        var iceServers = null;
-        if (servers && Array.isArray(servers.iceServers)) {
-          iceServers = servers.iceServers;
-          for (var i = 0; i < iceServers.length; i++) {
-            if (iceServers[i].urls && !iceServers[i].url) {
-              iceServers[i].url = iceServers[i].urls;
-            }
-            iceServers[i].hasCredentials = AdapterJS.
-              isDefined(iceServers[i].username) &&
-              AdapterJS.isDefined(iceServers[i].credential);
-          }
-        }
         var mandatory = (constraints && constraints.mandatory) ?
           constraints.mandatory : null;
         var optional = (constraints && constraints.optional) ?

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -959,7 +959,6 @@ if ( navigator.mozGetUserMedia ||
       if (servers && Array.isArray(servers.iceServers)) {
         iceServers = servers.iceServers;
         for (var i = 0; i < iceServers.length; i++) {
-          // Legacy plugin versions compatibility
           if (iceServers[i].urls && !iceServers[i].url) {
             iceServers[i].url = iceServers[i].urls;
           }
@@ -972,8 +971,10 @@ if ( navigator.mozGetUserMedia ||
       if (AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION &&
           AdapterJS.WebRTCPlugin.plugin.PEER_CONNECTION_VERSION > 1) {
         // RTCPeerConnection prototype from the new spec
-        var s = { iceServers: iceServers };
-        return AdapterJS.WebRTCPlugin.plugin.PeerConnection(s);
+        if (iceServers) {
+          servers.iceServers = iceServers;
+        }
+        return AdapterJS.WebRTCPlugin.plugin.PeerConnection(servers);
       } else {
         var mandatory = (constraints && constraints.mandatory) ?
           constraints.mandatory : null;

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -959,6 +959,7 @@ if ( navigator.mozGetUserMedia ||
       if (servers && Array.isArray(servers.iceServers)) {
         iceServers = servers.iceServers;
         for (var i = 0; i < iceServers.length; i++) {
+          // Legacy plugin versions compatibility
           if (iceServers[i].urls && !iceServers[i].url) {
             iceServers[i].url = iceServers[i].urls;
           }


### PR DESCRIPTION
> NOTE: Still requiring testing

This commit simply copies logic for both new and old format of constructing the plugin `RTCPeerConnection` object.