### PR TITLE
change MediaStreamTrack from Object to Function type.

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -987,7 +987,7 @@ if ( navigator.mozGetUserMedia ||
       }
     };
 
-    MediaStreamTrack = {};
+    MediaStreamTrack = function(){};
     MediaStreamTrack.getSources = function (callback) {
       AdapterJS.WebRTCPlugin.callWhenPluginReady(function() {
         AdapterJS.WebRTCPlugin.plugin.GetSources(callback);


### PR DESCRIPTION
MediaStreamTrack is implemented by the browsers as an instance of function (with prototype), the current polyfill implementation as an object make this kind of check raise an error:

```
window.MediaStreamTrack  && 'aMethod' in window.MediaStreamTrack.prototype
```