### PR TITLE
fix adapter.screenshare.js  for Edge

### DIFF
--- a/publish/adapter.screenshare.js
+++ b/publish/adapter.screenshare.js
@@ -1527,7 +1527,7 @@ if ( navigator.mozGetUserMedia ||
                 url = server.urls[0];
               }
               if (url.indexOf('transport=udp') !== -1) {
-                self.iceServers.push({
+                self.iceOptions.iceServers.push({
                   username: server.username,
                   credential: server.credential,
                   urls: url


### PR DESCRIPTION
without this fix demo https://github.com/Temasys/Google-WebRTC-Samples/tree/master/src/content/peerconnection/pc1 changed to do connection for remote users with socket.io didnt work