### PR TITLE
Allow for pluginInfo overrides

### DIFF
--- a/source/pluginInfo.js
+++ b/source/pluginInfo.js
@@ -1,4 +1,4 @@
-AdapterJS.WebRTCPlugin.pluginInfo = {
+AdapterJS.WebRTCPlugin.pluginInfo = AdapterJS.WebRTCPlugin.pluginInfo || {
   prefix : 'Tem',
   plugName : 'TemWebRTCPlugin',
   pluginId : 'plugin0',
@@ -6,11 +6,15 @@ AdapterJS.WebRTCPlugin.pluginInfo = {
   onload : '__TemWebRTCReady0',
   portalLink : 'http://skylink.io/plugin/',
   downloadLink : null, //set below
-  companyName: 'Temasys'
+  companyName: 'Temasys',
+  downloadLinks : {
+    mac: 'http://bit.ly/1n77hco',
+    win: 'http://bit.ly/1kkS4FN'
+  }
 };
 if(!!navigator.platform.match(/^Mac/i)) {
-  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = 'http://bit.ly/1n77hco';
+  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = AdapterJS.WebRTCPlugin.pluginInfo.downloadLinks.mac || 'http://bit.ly/1n77hco';
 }
 else if(!!navigator.platform.match(/^Win/i)) {
-  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = 'http://bit.ly/1kkS4FN';
+  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = AdapterJS.WebRTCPlugin.pluginInfo.downloadLinks.win || 'http://bit.ly/1kkS4FN';
 }

--- a/source/pluginInfo.js
+++ b/source/pluginInfo.js
@@ -13,8 +13,8 @@ AdapterJS.WebRTCPlugin.pluginInfo = AdapterJS.WebRTCPlugin.pluginInfo || {
   }
 };
 if(!!navigator.platform.match(/^Mac/i)) {
-  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = AdapterJS.WebRTCPlugin.pluginInfo.downloadLinks.mac || 'http://bit.ly/1n77hco';
+  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = AdapterJS.WebRTCPlugin.pluginInfo.downloadLinks.mac;
 }
 else if(!!navigator.platform.match(/^Win/i)) {
-  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = AdapterJS.WebRTCPlugin.pluginInfo.downloadLinks.win || 'http://bit.ly/1kkS4FN';
+  AdapterJS.WebRTCPlugin.pluginInfo.downloadLink = AdapterJS.WebRTCPlugin.pluginInfo.downloadLinks.win;
 }


### PR DESCRIPTION
This changes allows the AdapterJS.WebRTCPlugin.pluginInfo object to be set externally via a shim.
Making it easier for organizations that have purchased a Temasys plugin to pull the latest AdapterJS without needed to maintain custom copies.

For those of you who are interested we are setting this information via a SystemJS shim like so,
in the package.json overrides section:
```javascript
"meta": {
  "<path/to/adapter/file/inside/of/module>/adapter.js": {
    "globals": {
      "AdapterJS": "<path/to/your/shim/file>/adapterGlobalShim.js"
     },
     "format": "cjs"
   }
}
```