### PR TITLE
AJS-274: Fixes for attachMediaStream API in Opera 39+ browsers

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -230,8 +230,8 @@ AdapterJS.isDefined = null;
 //   - 'plugin': Using the plugin implementation.
 AdapterJS.parseWebrtcDetectedBrowser = function () {
   var hasMatch = null;
-  if ((!!window.opr && !!opr.addons) || 
-    !!window.opera || 
+  if ((!!window.opr && !!opr.addons) ||
+    !!window.opera ||
     navigator.userAgent.indexOf(' OPR/') >= 0) {
     // Opera 8.0+
     webrtcDetectedBrowser = 'opera';
@@ -259,7 +259,7 @@ AdapterJS.parseWebrtcDetectedBrowser = function () {
     webrtcDetectedVersion = parseInt(hasMatch[1] || '0', 10);
     if (!webrtcDetectedVersion) {
       hasMatch = /\bMSIE[ :]+(\d+)/g.exec(navigator.userAgent) || [];
-      webrtcDetectedVersion = parseInt(hasMatch[1] || '0', 10);      
+      webrtcDetectedVersion = parseInt(hasMatch[1] || '0', 10);
     }
   } else if (!!window.StyleMedia) {
     // Edge 20+
@@ -269,7 +269,7 @@ AdapterJS.parseWebrtcDetectedBrowser = function () {
     // Chrome 1+
     // Bowser and Version set in Google's adapter
     webrtcDetectedType    = 'webkit';
-  } else if ((webrtcDetectedBrowser === 'chrome'|| webrtcDetectedBrowser === 'opera') && 
+  } else if ((webrtcDetectedBrowser === 'chrome'|| webrtcDetectedBrowser === 'opera') &&
     !!window.CSS) {
     // Blink engine detection
     webrtcDetectedBrowser = 'blink';
@@ -534,10 +534,10 @@ webrtcDetectedVersion = null;
 webrtcMinimumVersion  = null;
 
 // Check for browser types and react accordingly
-if ( navigator.mozGetUserMedia || 
-  navigator.webkitGetUserMedia || 
-  (navigator.mediaDevices && 
-    navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) ) { 
+if ( navigator.mozGetUserMedia ||
+  navigator.webkitGetUserMedia ||
+  (navigator.mediaDevices &&
+    navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) ) {
 
   ///////////////////////////////////////////////////////////////////
   // INJECTION OF GOOGLE'S ADAPTER.JS CONTENT
@@ -677,9 +677,21 @@ if ( navigator.mozGetUserMedia ||
   // Need to override attachMediaStream and reattachMediaStream
   // to support the plugin's logic
   attachMediaStream_base = attachMediaStream;
+
+  if (webrtcDetectedBrowser === 'opera') {
+    attachMediaStream_base = function (element, stream) {
+      if (webrtcDetectedVersion > 38) {
+        element.srcObject = stream;
+      } else if (typeof element.src !== 'undefined') {
+        element.src = URL.createObjectURL(stream);
+      }
+      // Else it doesn't work
+    };
+  }
+
   attachMediaStream = function (element, stream) {
     if ((webrtcDetectedBrowser === 'chrome' ||
-         webrtcDetectedBrowser === 'opera') && 
+         webrtcDetectedBrowser === 'opera') &&
         !stream) {
       // Chrome does not support "src = null"
       element.src = '';
@@ -938,11 +950,11 @@ if ( navigator.mozGetUserMedia ||
       if (typeof constraints !== 'undefined' && constraints !== null) {
         var invalidConstraits = false;
         invalidConstraits |= typeof constraints !== 'object';
-        invalidConstraits |= constraints.hasOwnProperty('mandatory') && 
-                              constraints.mandatory !== undefined && 
-                              constraints.mandatory !== null && 
+        invalidConstraits |= constraints.hasOwnProperty('mandatory') &&
+                              constraints.mandatory !== undefined &&
+                              constraints.mandatory !== null &&
                               constraints.mandatory.constructor !== Object;
-        invalidConstraits |= constraints.hasOwnProperty('optional') && 
+        invalidConstraits |= constraints.hasOwnProperty('optional') &&
                               constraints.optional !== undefined &&
                               constraints.optional !== null &&
                               !Array.isArray(constraints.optional);
@@ -1202,7 +1214,7 @@ if ( navigator.mozGetUserMedia ||
           propName = properties[prop];
 
           if (typeof propName.slice === 'function' &&
-              propName.slice(0,2) === 'on' && 
+              propName.slice(0,2) === 'on' &&
               typeof srcElem[propName] === 'function') {
               AdapterJS.addEvent(destElem, propName.slice(2), srcElem[propName]);
           }


### PR DESCRIPTION
As informed before, this fixes aims to:
- Resolve the issues that the [`attachMediaStream` API for `webkitGetUserMedia` detection](https://github.com/Temasys/AdapterJS/blob/0.13.3/publish/adapter.debug.js#L1054) that might not work for Opera browsers since their implementation of Chromium is not the same as the browser version.

PS: Ignore the whitespaces removal changes in this commit. These lines aren't actually really changed but my sublime plugin helps me remove unwanted spaces. The changes begins from [here](https://github.com/Temasys/AdapterJS/pull/214/commits/3ade793b48474ed42748b941d8cb2ab1cedf9945#diff-b1ee9bbe2f0ee05f1717e6f3fe0187d7R681).