### PR TITLE
AJS-278: Handle deprecation for "moz" interfaces correctly.

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -625,19 +625,6 @@ if ( (navigator.mozGetUserMedia ||
     && !((navigator.userAgent.match(/android/ig) || []).length === 0 &&
           (navigator.userAgent.match(/chrome/ig) || []).length === 0 && navigator.userAgent.indexOf('Safari/') > 0)) {
 
-  // Handle mozRTCPeerconnection deprecation..
-  if (typeof InstallTrigger !== 'undefined' || navigator.userAgent.indexOf('irefox') > 0) {
-    if (window.RTCPeerConnection) {
-      window.mozRTCPeerConnection = window.RTCPeerConnection;
-    }
-    if (window.RTCSessionDescription) {
-      window.mozRTCSessionDescription = window.RTCSessionDescription;
-    }
-    if (window.RTCICECandidate) {
-      window.mozRTCICECandidate = window.RTCICECandidate;
-    }
-  }
-
   ///////////////////////////////////////////////////////////////////
   // INJECTION OF GOOGLE'S ADAPTER.JS CONTENT
 

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -576,21 +576,16 @@ createIceServers = null;
 //------------------------------------------------------------
 
 //The RTCPeerConnection object.
-if (!window.RTCPeerConnection) {
-  RTCPeerConnection = null;
-}
+RTCPeerConnection = (typeof RTCPeerConnection === 'function') ?
+  RTCPeerConnection : null;
 
 // Creates RTCSessionDescription object for Plugin Browsers
-if (!window.RTCSessionDescription) {
-  RTCSessionDescription = (typeof RTCSessionDescription === 'function') ?
-    RTCSessionDescription : null;
-}
+RTCSessionDescription = (typeof RTCSessionDescription === 'function') ?
+  RTCSessionDescription : null;
 
 // Creates RTCIceCandidate object for Plugin Browsers
-if (!window.RTCIceCandidate) {
-  RTCIceCandidate = (typeof RTCIceCandidate === 'function') ?
-    RTCIceCandidate : null;
-}
+RTCIceCandidate = (typeof RTCIceCandidate === 'function') ?
+  RTCIceCandidate : null;
 
 // Get UserMedia (only difference is the prefix).
 // Code from Adam Barth.

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -576,15 +576,21 @@ createIceServers = null;
 //------------------------------------------------------------
 
 //The RTCPeerConnection object.
-RTCPeerConnection = null;
+if (!window.RTCPeerConnection) {
+  RTCPeerConnection = null;
+}
 
 // Creates RTCSessionDescription object for Plugin Browsers
-RTCSessionDescription = (typeof RTCSessionDescription === 'function') ?
-  RTCSessionDescription : null;
+if (!window.RTCSessionDescription) {
+  RTCSessionDescription = (typeof RTCSessionDescription === 'function') ?
+    RTCSessionDescription : null;
+}
 
 // Creates RTCIceCandidate object for Plugin Browsers
-RTCIceCandidate = (typeof RTCIceCandidate === 'function') ?
-  RTCIceCandidate : null;
+if (!window.RTCIceCandidate) {
+  RTCIceCandidate = (typeof RTCIceCandidate === 'function') ?
+    RTCIceCandidate : null;
+}
 
 // Get UserMedia (only difference is the prefix).
 // Code from Adam Barth.
@@ -618,6 +624,19 @@ if ( (navigator.mozGetUserMedia ||
        navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)))
     && !((navigator.userAgent.match(/android/ig) || []).length === 0 &&
           (navigator.userAgent.match(/chrome/ig) || []).length === 0 && navigator.userAgent.indexOf('Safari/') > 0)) {
+
+  // Handle mozRTCPeerconnection deprecation..
+  if (typeof InstallTrigger !== 'undefined' || navigator.userAgent.indexOf('irefox') > 0) {
+    if (window.RTCPeerConnection) {
+      window.mozRTCPeerConnection = window.RTCPeerConnection;
+    }
+    if (window.RTCSessionDescription) {
+      window.mozRTCSessionDescription = window.RTCSessionDescription;
+    }
+    if (window.RTCICECandidate) {
+      window.mozRTCICECandidate = window.RTCICECandidate;
+    }
+  }
 
   ///////////////////////////////////////////////////////////////////
   // INJECTION OF GOOGLE'S ADAPTER.JS CONTENT


### PR DESCRIPTION
This fixes the issue:
> WebRTC interfaces with the "moz" prefix (mozRTCPeerConnection, mozRTCSessionDescription, mozRTCIceCandidate) have been deprecated.

Since in [`webrtc/adapter` line](https://github.com/webrtc/adapter/blob/v2.0.3/src/js/firefox/firefox_shim.js#L65) it checks if the undeprecated `RTCPeerConnection` API exists before shimming it, but [in this line](https://github.com/Temasys/AdapterJS/blob/0.14.0/source/adapter.js#L579), we define the interfaces as `null` again, hence making `webrtc/adapter` code to polyfill it although it has been deprecated.