### PR TITLE
Adds forceGetAllCams if enabled in attachMediaStream.

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1255,6 +1255,7 @@ if ( (navigator.mozGetUserMedia ||
           '<param name="windowless" value="true" /> ' +
           '<param name="streamId" value="' + streamId + '" /> ' +
           '<param name="tag" value="' + tag + '" /> ' +
+          (AdapterJS.options.getAllCams ? '<param name="forceGetAllCams" value="True" />':'') +
           '</object>';
         while (temp.firstChild) {
           frag.appendChild(temp.firstChild);


### PR DESCRIPTION
When enabled AdapterJS.options.getAllCams this adds the needed params when executing attachMediaStream.
It is still not working for me for safari with latest plugin, but at least has the needed param.