### PR TITLE
github#226: added support for NotAllowedError on FF 

### DIFF
--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -51,7 +51,7 @@
             clearInterval(checkIfReady);
 
             baseGetUserMedia(updatedConstraints, successCb, function (error) {
-              if (['PermissionDeniedError', 'SecurityError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
+              if (['PermissionDeniedError', 'SecurityError', 'NotAllowedError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
                 AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_FF,
                   AdapterJS.TEXT.EXTENSION.BUTTON_FF,
                   'https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/', true, true);


### PR DESCRIPTION
when the screensharing extension in not available, FF now seems to return a ``NotAllowedError`` instead of ``PermissionDeniedError`` or ``SecurityError``.
Just add the former to the list of expected errors when the extension is not available.