### PR TITLE
github#229 HTTPS links

### DIFF
--- a/source/pluginInfo.js
+++ b/source/pluginInfo.js
@@ -4,12 +4,12 @@ AdapterJS.WebRTCPlugin.pluginInfo = AdapterJS.WebRTCPlugin.pluginInfo || {
   pluginId : 'plugin0',
   type : 'application/x-temwebrtcplugin',
   onload : '__TemWebRTCReady0',
-  portalLink : 'http://skylink.io/plugin/',
+  portalLink : 'https://skylink.io/plugin/',
   downloadLink : null, //set below
   companyName: 'Temasys',
   downloadLinks : {
-    mac: 'http://bit.ly/webrtcpluginpkg',
-    win: 'http://bit.ly/webrtcpluginmsi'
+    mac: 'https://bit.ly/webrtcpluginpkg',
+    win: 'https://bit.ly/webrtcpluginmsi'
   }
 };
 if(typeof AdapterJS.WebRTCPlugin.pluginInfo.downloadLinks !== "undefined" && AdapterJS.WebRTCPlugin.pluginInfo.downloadLinks !== null) {


### PR DESCRIPTION
From https://github.com/Temasys/AdapterJS/issues/229
"replace links like http://skylink.io/plugin/, http://bit.ly/webrtcpluginpkg, http://bit.ly/webrtcpluginmsi with https versions."