### PR TITLE
AJS-280: Fixes to define screensharing changes for gar.io case

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -43,13 +43,16 @@ AdapterJS.webRTCReady = function (callback) {
     throw new Error('Callback provided is not a function');
   }
 
-  if (true === AdapterJS.onwebrtcreadyDone) {
-    // All WebRTC interfaces are ready, just call the callback
-    callback(null !== AdapterJS.WebRTCPlugin.plugin);
-  } else {
-    // will be triggered automatically when your browser/plugin is ready.
-    AdapterJS._onwebrtcreadies.push(callback);
-  }
+  // Added this change to ensure sequential loading after the timeout configured in shimScreenshare.
+  setTimeout(function () {
+    if (true === AdapterJS.onwebrtcreadyDone) {
+      // All WebRTC interfaces are ready, just call the callback
+      callback(null !== AdapterJS.WebRTCPlugin.plugin);
+    } else {
+      // will be triggered automatically when your browser/plugin is ready.
+      AdapterJS._onwebrtcreadies.push(callback);
+    }
+  }, typeof AdapterJS._screenshareBrowserifyTimeout === 'number' ? AdapterJS._screenshareBrowserifyTimeout : 0);
 };
 
 // Plugin namespace

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -14,6 +14,8 @@
       BUTTON_CHROME: 'Go to Chrome Web Store'
     };
 
+    AdapterJS._screenshareBrowserifyTimeout = 1;
+
     var clone = function(obj) {
       if (null === obj || 'object' !== typeof obj) {
         return obj;
@@ -237,5 +239,5 @@
 
   // NOTE: Temp hotfix for gar.io or webrtc/adapter browserify replacements.
   // Should be done properly with browserify changes.
-  setTimeout(shimScreenshare, 1);
+  setTimeout(shimScreenshare, AdapterJS._screenshareBrowserifyTimeout);
 })();

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -4,6 +4,7 @@
 
   var shimScreenshare = function () {
     var baseGetUserMedia = null;
+    var replaceGetUserMedia = null;
 
     AdapterJS.TEXT.EXTENSION = {
       REQUIRE_INSTALLATION_FF: 'To enable screensharing you need to install the Skylink WebRTC tools Firefox Add-on.',
@@ -28,8 +29,7 @@
 
     if (window.navigator.mozGetUserMedia) {
       baseGetUserMedia = window.navigator.getUserMedia;
-
-      navigator.getUserMedia = function (constraints, successCb, failureCb) {
+      replaceGetUserMedia = function (constraints, successCb, failureCb) {
 
         if (constraints && constraints.video && !!constraints.video.mediaSource) {
           // intercepting screensharing requests
@@ -68,7 +68,7 @@
         }
       };
 
-      AdapterJS.getUserMedia = window.getUserMedia = navigator.getUserMedia;
+      AdapterJS.getUserMedia = getUserMedia = window.getUserMedia = navigator.getUserMedia = window.navigator.getUserMedia = replaceGetUserMedia;
       /* Comment out to prevent recursive errors
       navigator.mediaDevices.getUserMedia = function(constraints) {
         return new Promise(function(resolve, reject) {
@@ -78,8 +78,7 @@
 
     } else if (window.navigator.webkitGetUserMedia && window.webrtcDetectedBrowser !== 'safari') {
       baseGetUserMedia = window.navigator.getUserMedia;
-
-      navigator.getUserMedia = function (constraints, successCb, failureCb) {
+      replaceGetUserMedia = function (constraints, successCb, failureCb) {
         if (constraints && constraints.video && !!constraints.video.mediaSource) {
           if (window.webrtcDetectedBrowser !== 'chrome') {
             // This is Opera, which does not support screensharing
@@ -154,10 +153,10 @@
         }
       };
 
-      AdapterJS.getUserMedia = window.getUserMedia = navigator.getUserMedia;
-      navigator.mediaDevices.getUserMedia = function(constraints) {
+      AdapterJS.getUserMedia = getUserMedia = window.getUserMedia = navigator.getUserMedia = window.navigator.getUserMedia = replaceGetUserMedia;
+      navigator.mediaDevices.getUserMedia = window.navigator.mediaDevices.getUserMedia = function(constraints) {
         return new Promise(function(resolve, reject) {
-          window.getUserMedia(constraints, resolve, reject);
+          replaceGetUserMedia(constraints, resolve, reject);
         });
       };
 
@@ -167,8 +166,7 @@
 
     } else {
       baseGetUserMedia = window.navigator.getUserMedia;
-
-      navigator.getUserMedia = function (constraints, successCb, failureCb) {
+      replaceGetUserMedia = function (constraints, successCb, failureCb) {
         if (constraints && constraints.video && !!constraints.video.mediaSource) {
           // would be fine since no methods
           var updatedConstraints = clone(constraints);
@@ -196,11 +194,10 @@
         }
       };
 
-      AdapterJS.getUserMedia = getUserMedia = 
-         window.getUserMedia = navigator.getUserMedia;
+      AdapterJS.getUserMedia = getUserMedia = window.getUserMedia = navigator.getUserMedia = window.navigator.getUserMedia = replaceGetUserMedia;
       if ( navigator.mediaDevices &&
         typeof Promise !== 'undefined') {
-        navigator.mediaDevices.getUserMedia = requestUserMedia;
+        navigator.mediaDevices.getUserMedia = window.navigator.mediaDevices.getUserMedia = replaceGetUserMedia;
       }
     }
 

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -1,7 +1,4 @@
-(function () {
-
-  'use strict';
-
+var shimScreenshare = function () {
   var baseGetUserMedia = null;
 
   AdapterJS.TEXT.EXTENSION = {
@@ -233,4 +230,10 @@
   } else if (window.webrtcDetectedBrowser === 'opera') {
     console.warn('Opera does not support screensharing feature in getUserMedia');
   }
-})();
+};
+
+shimScreenshare();
+
+setTimeout(function () {
+  shimScreenshare();
+}, 1);

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -197,9 +197,12 @@
       };
 
       AdapterJS.getUserMedia = getUserMedia = window.getUserMedia = navigator.getUserMedia = window.navigator.getUserMedia = replaceGetUserMedia;
-      if ( navigator.mediaDevices &&
-        typeof Promise !== 'undefined') {
-        navigator.mediaDevices.getUserMedia = window.navigator.mediaDevices.getUserMedia = replaceGetUserMedia;
+      if (navigator.mediaDevices && typeof Promise !== 'undefined') {
+        navigator.mediaDevices.getUserMedia = window.navigator.mediaDevices.getUserMedia = function(constraints) {
+          return new Promise(function(resolve, reject) {
+            replaceGetUserMedia(constraints, resolve, reject);
+          });
+        };
       }
     }
 

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -1,239 +1,244 @@
-var shimScreenshare = function () {
-  var baseGetUserMedia = null;
+(function () {
 
-  AdapterJS.TEXT.EXTENSION = {
-    REQUIRE_INSTALLATION_FF: 'To enable screensharing you need to install the Skylink WebRTC tools Firefox Add-on.',
-    REQUIRE_INSTALLATION_CHROME: 'To enable screensharing you need to install the Skylink WebRTC tools Chrome Extension.',
-    REQUIRE_REFRESH: 'Please refresh this page after the Skylink WebRTC tools extension has been installed.',
-    BUTTON_FF: 'Install Now',
-    BUTTON_CHROME: 'Go to Chrome Web Store'
-  };
+  'use strict';
 
-  var clone = function(obj) {
-    if (null === obj || 'object' !== typeof obj) {
-      return obj;
-    }
-    var copy = obj.constructor();
-    for (var attr in obj) {
-      if (obj.hasOwnProperty(attr)) {
-        copy[attr] = obj[attr];
+  var shimScreenshare = function () {
+    var baseGetUserMedia = null;
+
+    AdapterJS.TEXT.EXTENSION = {
+      REQUIRE_INSTALLATION_FF: 'To enable screensharing you need to install the Skylink WebRTC tools Firefox Add-on.',
+      REQUIRE_INSTALLATION_CHROME: 'To enable screensharing you need to install the Skylink WebRTC tools Chrome Extension.',
+      REQUIRE_REFRESH: 'Please refresh this page after the Skylink WebRTC tools extension has been installed.',
+      BUTTON_FF: 'Install Now',
+      BUTTON_CHROME: 'Go to Chrome Web Store'
+    };
+
+    var clone = function(obj) {
+      if (null === obj || 'object' !== typeof obj) {
+        return obj;
       }
-    }
-    return copy;
-  };
-
-  if (window.navigator.mozGetUserMedia) {
-    baseGetUserMedia = window.navigator.getUserMedia;
-
-    navigator.getUserMedia = function (constraints, successCb, failureCb) {
-
-      if (constraints && constraints.video && !!constraints.video.mediaSource) {
-        // intercepting screensharing requests
-
-        // Invalid mediaSource for firefox, only "screen" and "window" are supported
-        if (constraints.video.mediaSource !== 'screen' && constraints.video.mediaSource !== 'window') {
-          failureCb(new Error('GetUserMedia: Only "screen" and "window" are supported as mediaSource constraints'));
-          return;
+      var copy = obj.constructor();
+      for (var attr in obj) {
+        if (obj.hasOwnProperty(attr)) {
+          copy[attr] = obj[attr];
         }
+      }
+      return copy;
+    };
 
-        var updatedConstraints = clone(constraints);
+    if (window.navigator.mozGetUserMedia) {
+      baseGetUserMedia = window.navigator.getUserMedia;
 
-        //constraints.video.mediaSource = constraints.video.mediaSource;
-        updatedConstraints.video.mozMediaSource = updatedConstraints.video.mediaSource;
+      navigator.getUserMedia = function (constraints, successCb, failureCb) {
 
-        // so generally, it requires for document.readyState to be completed before the getUserMedia could be invoked.
-        // strange but this works anyway
-        var checkIfReady = setInterval(function () {
-          if (document.readyState === 'complete') {
-            clearInterval(checkIfReady);
+        if (constraints && constraints.video && !!constraints.video.mediaSource) {
+          // intercepting screensharing requests
 
-            baseGetUserMedia(updatedConstraints, successCb, function (error) {
-              if (['PermissionDeniedError', 'SecurityError', 'NotAllowedError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
-                AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_FF,
-                  AdapterJS.TEXT.EXTENSION.BUTTON_FF,
-                  'https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/', true, true);
-              } else {
-                failureCb(error);
+          // Invalid mediaSource for firefox, only "screen" and "window" are supported
+          if (constraints.video.mediaSource !== 'screen' && constraints.video.mediaSource !== 'window') {
+            failureCb(new Error('GetUserMedia: Only "screen" and "window" are supported as mediaSource constraints'));
+            return;
+          }
+
+          var updatedConstraints = clone(constraints);
+
+          //constraints.video.mediaSource = constraints.video.mediaSource;
+          updatedConstraints.video.mozMediaSource = updatedConstraints.video.mediaSource;
+
+          // so generally, it requires for document.readyState to be completed before the getUserMedia could be invoked.
+          // strange but this works anyway
+          var checkIfReady = setInterval(function () {
+            if (document.readyState === 'complete') {
+              clearInterval(checkIfReady);
+
+              baseGetUserMedia(updatedConstraints, successCb, function (error) {
+                if (['PermissionDeniedError', 'SecurityError', 'NotAllowedError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
+                  AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_FF,
+                    AdapterJS.TEXT.EXTENSION.BUTTON_FF,
+                    'https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/', true, true);
+                } else {
+                  failureCb(error);
+                }
+              });
+            }
+          }, 1);
+
+        } else { // regular GetUserMediaRequest
+          baseGetUserMedia(constraints, successCb, failureCb);
+        }
+      };
+
+      AdapterJS.getUserMedia = window.getUserMedia = navigator.getUserMedia;
+      /* Comment out to prevent recursive errors
+      navigator.mediaDevices.getUserMedia = function(constraints) {
+        return new Promise(function(resolve, reject) {
+          window.getUserMedia(constraints, resolve, reject);
+        });
+      };*/
+
+    } else if (window.navigator.webkitGetUserMedia && window.webrtcDetectedBrowser !== 'safari') {
+      baseGetUserMedia = window.navigator.getUserMedia;
+
+      navigator.getUserMedia = function (constraints, successCb, failureCb) {
+        if (constraints && constraints.video && !!constraints.video.mediaSource) {
+          if (window.webrtcDetectedBrowser !== 'chrome') {
+            // This is Opera, which does not support screensharing
+            failureCb(new Error('Current browser does not support screensharing'));
+            return;
+          }
+
+          // would be fine since no methods
+          var updatedConstraints = clone(constraints);
+
+          var chromeCallback = function(error, sourceId) {
+            if(!error) {
+              updatedConstraints.video.mandatory = updatedConstraints.video.mandatory || {};
+              updatedConstraints.video.mandatory.chromeMediaSource = 'desktop';
+              updatedConstraints.video.mandatory.maxWidth = window.screen.width > 1920 ? window.screen.width : 1920;
+              updatedConstraints.video.mandatory.maxHeight = window.screen.height > 1080 ? window.screen.height : 1080;
+
+              if (sourceId) {
+                updatedConstraints.video.mandatory.chromeMediaSourceId = sourceId;
               }
-            });
-          }
-        }, 1);
 
-      } else { // regular GetUserMediaRequest
-        baseGetUserMedia(constraints, successCb, failureCb);
+              delete updatedConstraints.video.mediaSource;
+
+              baseGetUserMedia(updatedConstraints, successCb, failureCb);
+
+            } else { // GUM failed
+              if (error === 'permission-denied') {
+                failureCb(new Error('Permission denied for screen retrieval'));
+              } else {
+                // NOTE(J-O): I don't think we ever pass in here. 
+                // A failure to capture the screen does not lead here.
+                failureCb(new Error('Failed retrieving selected screen'));
+              }
+            }
+          };
+
+          var onIFrameCallback = function (event) {
+            if (!event.data) {
+              return;
+            }
+
+            if (event.data.chromeMediaSourceId) {
+              if (event.data.chromeMediaSourceId === 'PermissionDeniedError') {
+                  chromeCallback('permission-denied');
+              } else {
+                chromeCallback(null, event.data.chromeMediaSourceId);
+              }
+            }
+
+            if (event.data.chromeExtensionStatus) {
+              if (event.data.chromeExtensionStatus === 'not-installed') {
+                AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_CHROME,
+                  AdapterJS.TEXT.EXTENSION.BUTTON_CHROME,
+                  event.data.data, true, true);
+              } else {
+                chromeCallback(event.data.chromeExtensionStatus, null);
+              }
+            }
+
+            // this event listener is no more needed
+            window.removeEventListener('message', onIFrameCallback);
+          };
+
+          window.addEventListener('message', onIFrameCallback);
+
+          postFrameMessage({
+            captureSourceId: true
+          });
+
+        } else {
+          baseGetUserMedia(constraints, successCb, failureCb);
+        }
+      };
+
+      AdapterJS.getUserMedia = window.getUserMedia = navigator.getUserMedia;
+      navigator.mediaDevices.getUserMedia = function(constraints) {
+        return new Promise(function(resolve, reject) {
+          window.getUserMedia(constraints, resolve, reject);
+        });
+      };
+
+    } else if (navigator.mediaDevices && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) {
+      // nothing here because edge does not support screensharing
+      console.warn('Edge does not support screensharing feature in getUserMedia');
+
+    } else {
+      baseGetUserMedia = window.navigator.getUserMedia;
+
+      navigator.getUserMedia = function (constraints, successCb, failureCb) {
+        if (constraints && constraints.video && !!constraints.video.mediaSource) {
+          // would be fine since no methods
+          var updatedConstraints = clone(constraints);
+
+          // wait for plugin to be ready
+          AdapterJS.WebRTCPlugin.callWhenPluginReady(function() {
+            // check if screensharing feature is available
+            if (!!AdapterJS.WebRTCPlugin.plugin.HasScreensharingFeature &&
+              !!AdapterJS.WebRTCPlugin.plugin.isScreensharingAvailable) {
+              // set the constraints
+              updatedConstraints.video.optional = updatedConstraints.video.optional || [];
+              updatedConstraints.video.optional.push({
+                sourceId: AdapterJS.WebRTCPlugin.plugin.screensharingKey || 'Screensharing'
+              });
+
+              delete updatedConstraints.video.mediaSource;
+            } else {
+              failureCb(new Error('Your version of the WebRTC plugin does not support screensharing'));
+              return;
+            }
+            baseGetUserMedia(updatedConstraints, successCb, failureCb);
+          });
+        } else {
+          baseGetUserMedia(constraints, successCb, failureCb);
+        }
+      };
+
+      AdapterJS.getUserMedia = getUserMedia = 
+         window.getUserMedia = navigator.getUserMedia;
+      if ( navigator.mediaDevices &&
+        typeof Promise !== 'undefined') {
+        navigator.mediaDevices.getUserMedia = requestUserMedia;
       }
-    };
+    }
 
-    AdapterJS.getUserMedia = window.getUserMedia = navigator.getUserMedia;
-    /* Comment out to prevent recursive errors
-    navigator.mediaDevices.getUserMedia = function(constraints) {
-      return new Promise(function(resolve, reject) {
-        window.getUserMedia(constraints, resolve, reject);
-      });
-    };*/
+    // For chrome, use an iframe to load the screensharing extension
+    // in the correct domain.
+    // Modify here for custom screensharing extension in chrome
+    if (window.webrtcDetectedBrowser === 'chrome') {
+      var iframe = document.createElement('iframe');
 
-  } else if (window.navigator.webkitGetUserMedia && window.webrtcDetectedBrowser !== 'safari') {
-    baseGetUserMedia = window.navigator.getUserMedia;
+      iframe.onload = function() {
+        iframe.isLoaded = true;
+      };
 
-    navigator.getUserMedia = function (constraints, successCb, failureCb) {
-      if (constraints && constraints.video && !!constraints.video.mediaSource) {
-        if (window.webrtcDetectedBrowser !== 'chrome') {
-          // This is Opera, which does not support screensharing
-          failureCb(new Error('Current browser does not support screensharing'));
+      iframe.src = 'https://cdn.temasys.com.sg/skylink/extensions/detectRTC.html';
+      iframe.style.display = 'none';
+
+      (document.body || document.documentElement).appendChild(iframe);
+
+      var postFrameMessage = function (object) { // jshint ignore:line
+        object = object || {};
+
+        if (!iframe.isLoaded) {
+          setTimeout(function () {
+            iframe.contentWindow.postMessage(object, '*');
+          }, 100);
           return;
         }
 
-        // would be fine since no methods
-        var updatedConstraints = clone(constraints);
-
-        var chromeCallback = function(error, sourceId) {
-          if(!error) {
-            updatedConstraints.video.mandatory = updatedConstraints.video.mandatory || {};
-            updatedConstraints.video.mandatory.chromeMediaSource = 'desktop';
-            updatedConstraints.video.mandatory.maxWidth = window.screen.width > 1920 ? window.screen.width : 1920;
-            updatedConstraints.video.mandatory.maxHeight = window.screen.height > 1080 ? window.screen.height : 1080;
-
-            if (sourceId) {
-              updatedConstraints.video.mandatory.chromeMediaSourceId = sourceId;
-            }
-
-            delete updatedConstraints.video.mediaSource;
-
-            baseGetUserMedia(updatedConstraints, successCb, failureCb);
-
-          } else { // GUM failed
-            if (error === 'permission-denied') {
-              failureCb(new Error('Permission denied for screen retrieval'));
-            } else {
-              // NOTE(J-O): I don't think we ever pass in here. 
-              // A failure to capture the screen does not lead here.
-              failureCb(new Error('Failed retrieving selected screen'));
-            }
-          }
-        };
-
-        var onIFrameCallback = function (event) {
-          if (!event.data) {
-            return;
-          }
-
-          if (event.data.chromeMediaSourceId) {
-            if (event.data.chromeMediaSourceId === 'PermissionDeniedError') {
-                chromeCallback('permission-denied');
-            } else {
-              chromeCallback(null, event.data.chromeMediaSourceId);
-            }
-          }
-
-          if (event.data.chromeExtensionStatus) {
-            if (event.data.chromeExtensionStatus === 'not-installed') {
-              AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_CHROME,
-                AdapterJS.TEXT.EXTENSION.BUTTON_CHROME,
-                event.data.data, true, true);
-            } else {
-              chromeCallback(event.data.chromeExtensionStatus, null);
-            }
-          }
-
-          // this event listener is no more needed
-          window.removeEventListener('message', onIFrameCallback);
-        };
-
-        window.addEventListener('message', onIFrameCallback);
-
-        postFrameMessage({
-          captureSourceId: true
-        });
-
-      } else {
-        baseGetUserMedia(constraints, successCb, failureCb);
-      }
-    };
-
-    AdapterJS.getUserMedia = window.getUserMedia = navigator.getUserMedia;
-    navigator.mediaDevices.getUserMedia = function(constraints) {
-      return new Promise(function(resolve, reject) {
-        window.getUserMedia(constraints, resolve, reject);
-      });
-    };
-
-  } else if (navigator.mediaDevices && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) {
-    // nothing here because edge does not support screensharing
-    console.warn('Edge does not support screensharing feature in getUserMedia');
-
-  } else {
-    baseGetUserMedia = window.navigator.getUserMedia;
-
-    navigator.getUserMedia = function (constraints, successCb, failureCb) {
-      if (constraints && constraints.video && !!constraints.video.mediaSource) {
-        // would be fine since no methods
-        var updatedConstraints = clone(constraints);
-
-        // wait for plugin to be ready
-        AdapterJS.WebRTCPlugin.callWhenPluginReady(function() {
-          // check if screensharing feature is available
-          if (!!AdapterJS.WebRTCPlugin.plugin.HasScreensharingFeature &&
-            !!AdapterJS.WebRTCPlugin.plugin.isScreensharingAvailable) {
-            // set the constraints
-            updatedConstraints.video.optional = updatedConstraints.video.optional || [];
-            updatedConstraints.video.optional.push({
-              sourceId: AdapterJS.WebRTCPlugin.plugin.screensharingKey || 'Screensharing'
-            });
-
-            delete updatedConstraints.video.mediaSource;
-          } else {
-            failureCb(new Error('Your version of the WebRTC plugin does not support screensharing'));
-            return;
-          }
-          baseGetUserMedia(updatedConstraints, successCb, failureCb);
-        });
-      } else {
-        baseGetUserMedia(constraints, successCb, failureCb);
-      }
-    };
-
-    AdapterJS.getUserMedia = getUserMedia = 
-       window.getUserMedia = navigator.getUserMedia;
-    if ( navigator.mediaDevices &&
-      typeof Promise !== 'undefined') {
-      navigator.mediaDevices.getUserMedia = requestUserMedia;
+        iframe.contentWindow.postMessage(object, '*');
+      };
+    } else if (window.webrtcDetectedBrowser === 'opera') {
+      console.warn('Opera does not support screensharing feature in getUserMedia');
     }
-  }
+  };
 
-  // For chrome, use an iframe to load the screensharing extension
-  // in the correct domain.
-  // Modify here for custom screensharing extension in chrome
-  if (window.webrtcDetectedBrowser === 'chrome') {
-    var iframe = document.createElement('iframe');
-
-    iframe.onload = function() {
-      iframe.isLoaded = true;
-    };
-
-    iframe.src = 'https://cdn.temasys.com.sg/skylink/extensions/detectRTC.html';
-    iframe.style.display = 'none';
-
-    (document.body || document.documentElement).appendChild(iframe);
-
-    var postFrameMessage = function (object) { // jshint ignore:line
-      object = object || {};
-
-      if (!iframe.isLoaded) {
-        setTimeout(function () {
-          iframe.contentWindow.postMessage(object, '*');
-        }, 100);
-        return;
-      }
-
-      iframe.contentWindow.postMessage(object, '*');
-    };
-  } else if (window.webrtcDetectedBrowser === 'opera') {
-    console.warn('Opera does not support screensharing feature in getUserMedia');
-  }
-};
-
-shimScreenshare();
-
-setTimeout(function () {
   shimScreenshare();
-}, 1);
+
+  // NOTE: Temp hotfix for gar.io or webrtc/adapter browserify replacements.
+  // Should be done properly with browserify changes.
+  setTimeout(shimScreenshare, 1);
+})();


### PR DESCRIPTION
**How to reproduce the original issue:**
Run getaroom.io locally with AdapterJS `0.14.0` changes and notice that if you invoke the screenshare button, nothing happens. If you check `window.navigator.getUserMedia`, it gives you the `webrtc/adapter` shim.

Note that do not test in getaroom.io production since it uses AdapterJS `0.13.4` which does not have problems.

This could be related to some browserify output changes from `webrtc/adapter` which causes the overrides not to work in getaroom.io. This might cause issues for people using requirejs or reactjs library as they are used by developers. In order to fix it temporarily, a timeout was set to define the screensharing changes again, and to make the code run sequentially, the `AdapterJS.webrtcReady` follows the same timeout value before triggering the callback ready function.

Perhaps we should move to use browserify just as what `webrtc/adapter` is using to make proper fixes.

PS: I doubt these fixes are the best but it works for now. I think we should consider proper fixes to prevent related errors.
