### PR TITLE
Firefox add-on is not triggered due to Error name change from "SecurityError" to "NotAllowedError"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AdapterJS provides polyfills and cross-browser helpers for WebRTC. It wraps arou
 | Browsers          | Min. Version | OS Platform              | Screensharing             | 
 | ----------------- | ------------ | ------------------------ | ------------------------- | 
 | Chrome \ Chromium | `38`         | MacOS / Win / Ubuntu / Android | Yes (w [Extension](https://chrome.google.com/webstore/detail/skylink-webrtc-tools/ljckddiekopnnjoeaiofddfhgnbdoafc))         |
-| Firefox           | `31`         | MacOS / Win / Ubuntu / Android | Yes (w [Extension](https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/))         |
+| Firefox           | `33`         | MacOS / Win / Ubuntu / Android | Yes (w [Extension](https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/))         |
 | Opera             | `26`         | MacOS / Win / Ubuntu / Android |  -                        | 
 | Edge              | `13.10547`^  | Win                      |  -                        |
 | Bowser            | `0`          | iOS                      |  -                        |

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -322,7 +322,7 @@ AdapterJS.parseWebrtcDetectedBrowser = function () {
 
     webrtcDetectedBrowser   = 'firefox';
     webrtcDetectedVersion   = parseInt(hasMatch[1] || '0', 10);
-    webrtcMinimumVersion    = 31;
+    webrtcMinimumVersion    = 33;
     webrtcDetectedType      = 'moz';
     webrtcDetectedDCSupport = 'SCTP';
 

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -51,7 +51,7 @@
             clearInterval(checkIfReady);
 
             baseGetUserMedia(updatedConstraints, successCb, function (error) {
-              if (['PermissionDeniedError', 'SecurityError', 'NotAllowedError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
+              if (['NotAllowedError', 'PermissionDeniedError', 'SecurityError', 'NotAllowedError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
                 AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_FF,
                   AdapterJS.TEXT.EXTENSION.BUTTON_FF,
                   'https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/', true, true);


### PR DESCRIPTION
This commit contains:
- Fixes for the change from "SecurityError" to "NotAllowedError" as defined in this [bugzilla ticket here](https://bugzilla.mozilla.org/show_bug.cgi?id=1257950).
- Bump to Firefox min version `33` as Firefox browser screensharing is only supported from that version onwards.
