### PR TITLE
Update bowser support on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ AdapterJS provides polyfills and cross-browser helpers for WebRTC. It wraps arou
 | Firefox           | `33`         | MacOS / Win / Ubuntu / Android | Yes (w [Extension](https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/))         |
 | Opera             | `26`         | MacOS / Win / Ubuntu / Android |  -                        | 
 | Edge              | `13.10547`^  | Win                      |  -                        |
-| Bowser            | `0.6.1`      | iOS 9.x and below^^       |  -                        |
+| Bowser            | `0.6.1`      | iOS 9.x only**           |  -                        |
 | Safari (Plugin)   | `7`          | MacOS                    | Yes ([custom build Plugin](https://temasys.io/plugin/#commercial-licensing)) |
 | IE (Plugin)       | `9`          | Win                      | Yes ([custom build Plugin](https://temasys.io/plugin/#commercial-licensing)) |
-^Note that currently Edge doesn't support `RTCDataChannel` API.
-^^There seems to be issues for Bowser version `0.6.1` working with iOS 10.x version.
+*Note that currently Edge doesn't support `RTCDataChannel` API.
+**There seems to be issues for Bowser version `0.6.1` working with iOS 10.x version.
 
 ### How it looks like if WebRTC is not supported by browser
 ![Plugin Install Bar in IE and Safari](http://temasys.github.io/resources/img/adapterheader.png)

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ AdapterJS provides polyfills and cross-browser helpers for WebRTC. It wraps arou
 | Firefox           | `33`         | MacOS / Win / Ubuntu / Android | Yes (w [Extension](https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/))         |
 | Opera             | `26`         | MacOS / Win / Ubuntu / Android |  -                        | 
 | Edge              | `13.10547`^  | Win                      |  -                        |
-| Bowser            | `0.6.1`      | iOS 9+ and below         |  -                        |
+| Bowser            | `0.6.1`      | iOS 9+ and below^^       |  -                        |
 | Safari (Plugin)   | `7`          | MacOS                    | Yes ([custom build Plugin](https://temasys.io/plugin/#commercial-licensing)) |
 | IE (Plugin)       | `9`          | Win                      | Yes ([custom build Plugin](https://temasys.io/plugin/#commercial-licensing)) |
 ^Note that currently Edge doesn't support `RTCDataChannel` API.
+^^There seems to be issues for Bowser version `0.6.1` working with iOS 10+ version.
 
 ### How it looks like if WebRTC is not supported by browser
 ![Plugin Install Bar in IE and Safari](http://temasys.github.io/resources/img/adapterheader.png)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ AdapterJS provides polyfills and cross-browser helpers for WebRTC. It wraps arou
 | Firefox           | `33`         | MacOS / Win / Ubuntu / Android | Yes (w [Extension](https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/))         |
 | Opera             | `26`         | MacOS / Win / Ubuntu / Android |  -                        | 
 | Edge              | `13.10547`^  | Win                      |  -                        |
-| Bowser            | `0.6.1`      | iOS 9+ and below^^       |  -                        |
+| Bowser            | `0.6.1`      | iOS 9.x and below^^       |  -                        |
 | Safari (Plugin)   | `7`          | MacOS                    | Yes ([custom build Plugin](https://temasys.io/plugin/#commercial-licensing)) |
 | IE (Plugin)       | `9`          | Win                      | Yes ([custom build Plugin](https://temasys.io/plugin/#commercial-licensing)) |
 ^Note that currently Edge doesn't support `RTCDataChannel` API.
-^^There seems to be issues for Bowser version `0.6.1` working with iOS 10+ version.
+^^There seems to be issues for Bowser version `0.6.1` working with iOS 10.x version.
 
 ### How it looks like if WebRTC is not supported by browser
 ![Plugin Install Bar in IE and Safari](http://temasys.github.io/resources/img/adapterheader.png)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ AdapterJS provides polyfills and cross-browser helpers for WebRTC. It wraps arou
 | Firefox           | `33`         | MacOS / Win / Ubuntu / Android | Yes (w [Extension](https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/))         |
 | Opera             | `26`         | MacOS / Win / Ubuntu / Android |  -                        | 
 | Edge              | `13.10547`^  | Win                      |  -                        |
-| Bowser            | `0`          | iOS                      |  -                        |
+| Bowser            | `0.6.1`      | iOS 9+ and below         |  -                        |
 | Safari (Plugin)   | `7`          | MacOS                    | Yes ([custom build Plugin](https://temasys.io/plugin/#commercial-licensing)) |
 | IE (Plugin)       | `9`          | Win                      | Yes ([custom build Plugin](https://temasys.io/plugin/#commercial-licensing)) |
 ^Note that currently Edge doesn't support `RTCDataChannel` API.


### PR DESCRIPTION
It seems like bowser (current latest version is `0.6.1`) does not work with iOS 10+. Tested and seems like it only works on iOS 9+.

See the related ticket: [EricssonResearch/bowser#97](https://github.com/EricssonResearch/bowser/issues/97)