### PR TITLE
AJS-250: Fixes for "isIE" undefined error throwing when clicking button on notification bar

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1,5 +1,6 @@
 // Adapter's interface.
 var AdapterJS = AdapterJS || {};
+AdapterJS.isPluginNotificationBar = false;
 
 // Browserify compatibility
 if(typeof exports !== 'undefined') {
@@ -417,22 +418,24 @@ AdapterJS.renderNotificationBar = function (text, buttonText, buttonLink, openNe
         e.cancelBubble = true;
       } catch(error) { }
 
-      var pluginInstallInterval = setInterval(function(){
-        if(! isIE) {
-          navigator.plugins.refresh(false);
-        }
-        AdapterJS.WebRTCPlugin.isPluginInstalled(
-          AdapterJS.WebRTCPlugin.pluginInfo.prefix,
-          AdapterJS.WebRTCPlugin.pluginInfo.plugName,
-          AdapterJS.WebRTCPlugin.pluginInfo.type,
-          function() { // plugin now installed
-            clearInterval(pluginInstallInterval);
-            AdapterJS.WebRTCPlugin.defineWebRTCInterface();
-          },
-          function() {
-            // still no plugin detected, nothing to do
-          });
-      } , 500);
+      if (AdapterJS.isPluginNotificationBar) {
+        var pluginInstallInterval = setInterval(function(){
+          if(! isIE) {
+            navigator.plugins.refresh(false);
+          }
+          AdapterJS.WebRTCPlugin.isPluginInstalled(
+            AdapterJS.WebRTCPlugin.pluginInfo.prefix,
+            AdapterJS.WebRTCPlugin.pluginInfo.plugName,
+            AdapterJS.WebRTCPlugin.pluginInfo.type,
+            function() { // plugin now installed
+              clearInterval(pluginInstallInterval);
+              AdapterJS.WebRTCPlugin.defineWebRTCInterface();
+            },
+            function() {
+              // still no plugin detected, nothing to do
+            });
+        } , 500);
+      }
     });
 
     // On click on Cancel
@@ -884,6 +887,7 @@ if ( (navigator.mozGetUserMedia ||
   }
   AdapterJS.parseWebrtcDetectedBrowser();
   isIE = webrtcDetectedBrowser === 'IE';
+  AdapterJS.isPluginNotificationBar = true;
 
   /* jshint -W035 */
   AdapterJS.WebRTCPlugin.WaitForPluginReady = function() {

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1,6 +1,5 @@
 // Adapter's interface.
 var AdapterJS = AdapterJS || {};
-AdapterJS.isPluginNotificationBar = false;
 
 // Browserify compatibility
 if(typeof exports !== 'undefined') {
@@ -369,7 +368,7 @@ AdapterJS.addEvent = function(elem, evnt, func) {
   }
 };
 
-AdapterJS.renderNotificationBar = function (text, buttonText, buttonLink, openNewTab, displayRefreshBar) {
+AdapterJS.renderNotificationBar = function (text, buttonText, buttonLink, isPluginBar, openNewTab, displayRefreshBar) {
   // only inject once the page is ready
   if (document.readyState !== 'complete') {
     return;
@@ -418,7 +417,7 @@ AdapterJS.renderNotificationBar = function (text, buttonText, buttonLink, openNe
         e.cancelBubble = true;
       } catch(error) { }
 
-      if (AdapterJS.isPluginNotificationBar) {
+      if (isPluginBar) {
         var pluginInstallInterval = setInterval(function(){
           if(! isIE) {
             navigator.plugins.refresh(false);
@@ -887,7 +886,6 @@ if ( (navigator.mozGetUserMedia ||
   }
   AdapterJS.parseWebrtcDetectedBrowser();
   isIE = webrtcDetectedBrowser === 'IE';
-  AdapterJS.isPluginNotificationBar = true;
 
   /* jshint -W035 */
   AdapterJS.WebRTCPlugin.WaitForPluginReady = function() {
@@ -1386,7 +1384,7 @@ if ( (navigator.mozGetUserMedia ||
        popupString = AdapterJS.TEXT.PLUGIN.REQUIRE_INSTALLATION;
       }
 
-      AdapterJS.renderNotificationBar(popupString, AdapterJS.TEXT.PLUGIN.BUTTON, downloadLink);
+      AdapterJS.renderNotificationBar(popupString, AdapterJS.TEXT.PLUGIN.BUTTON, downloadLink, true);
     } else { // no download link, just print a generic explanation
       AdapterJS.renderNotificationBar(AdapterJS.TEXT.PLUGIN.NOT_SUPPORTED);
     }

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -54,7 +54,7 @@
               if (['NotAllowedError', 'PermissionDeniedError', 'SecurityError', 'NotAllowedError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
                 AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_FF,
                   AdapterJS.TEXT.EXTENSION.BUTTON_FF,
-                  'https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/', true, true);
+                  'https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/', false, true, true);
               } else {
                 failureCb(error);
               }
@@ -108,7 +108,7 @@
             if (error === 'permission-denied') {
               failureCb(new Error('Permission denied for screen retrieval'));
             } else {
-              // NOTE(J-O): I don't think we ever pass in here. 
+              // NOTE(J-O): I don't think we ever pass in here.
               // A failure to capture the screen does not lead here.
               failureCb(new Error('Failed retrieving selected screen'));
             }
@@ -132,7 +132,7 @@
             if (event.data.chromeExtensionStatus === 'not-installed') {
               AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_CHROME,
                 AdapterJS.TEXT.EXTENSION.BUTTON_CHROME,
-                event.data.data, true, true);
+                event.data.data, false, true, true);
             } else {
               chromeCallback(event.data.chromeExtensionStatus, null);
             }
@@ -195,7 +195,7 @@
       }
     };
 
-    AdapterJS.getUserMedia = getUserMedia = 
+    AdapterJS.getUserMedia = getUserMedia =
        window.getUserMedia = navigator.getUserMedia;
     if ( navigator.mediaDevices &&
       typeof Promise !== 'undefined') {

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -53,8 +53,19 @@
             baseGetUserMedia(updatedConstraints, successCb, function (error) {
               if (['NotAllowedError', 'PermissionDeniedError', 'SecurityError', 'NotAllowedError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
                 AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_FF,
-                  AdapterJS.TEXT.EXTENSION.BUTTON_FF,
-                  'https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/', false, true, true);
+                  AdapterJS.TEXT.EXTENSION.BUTTON_FF, function (e) {
+                  window.open('https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/', '_blank');
+                  if (e.target && e.target.parentElement && e.target.nextElementSibling &&
+                    e.target.nextElementSibling.click) {
+                    e.target.nextElementSibling.click();
+                  }
+                  // Trigger refresh bar
+                  AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION ?
+                    AdapterJS.TEXT.EXTENSION.REQUIRE_REFRESH : AdapterJS.TEXT.REFRESH.REQUIRE_REFRESH,
+                    AdapterJS.TEXT.REFRESH.BUTTON, function () {
+                    window.open('javascript:location.reload()', '_top');
+                  }); // jshint ignore:line
+                });
               } else {
                 failureCb(error);
               }
@@ -131,8 +142,19 @@
           if (event.data.chromeExtensionStatus) {
             if (event.data.chromeExtensionStatus === 'not-installed') {
               AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_CHROME,
-                AdapterJS.TEXT.EXTENSION.BUTTON_CHROME,
-                event.data.data, false, true, true);
+                AdapterJS.TEXT.EXTENSION.BUTTON_CHROME, function (e) {
+                window.open(event.data.data, '_blank');
+                if (e.target && e.target.parentElement && e.target.nextElementSibling &&
+                  e.target.nextElementSibling.click) {
+                  e.target.nextElementSibling.click();
+                }
+                // Trigger refresh bar
+                AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION ?
+                  AdapterJS.TEXT.EXTENSION.REQUIRE_REFRESH : AdapterJS.TEXT.REFRESH.REQUIRE_REFRESH,
+                  AdapterJS.TEXT.REFRESH.BUTTON, function () {
+                  window.open('javascript:location.reload()', '_top');
+                }); // jshint ignore:line
+              });
             } else {
               chromeCallback(event.data.chromeExtensionStatus, null);
             }


### PR DESCRIPTION
**What is the issue:**
![image](https://cloud.githubusercontent.com/assets/4675614/23212581/59b430b6-f942-11e6-96b8-70b93b23a89d.png)
When clicking on a button on a rendered notification bar that is on non-plugin browsers (chrome/firefox/opera), the "isIE is not defined" error throws. This is likely that "isIE" variable is only defined when case is plugin browser.

**How to reproduce it:**
- Go to a chrome/firefox/opera browser (non-plugin supported browser)
- Access any plugin demo. E.g.: https://plugin.temasys.com.sg/demo/src/content/peerconnection/trickle-ice/
- Key in this notification bar rendering to stimulate triggering for requiring add-on installation: AdapterJS.renderNotificationBar('install message', 'clickforerror', window.location.href, false, false);
- Click the "clickforerror" button
- Notice that "isIE" not defined error throws 

----
This PR aims to prevent the error from throwing and defining a variable to let `AdapterJS.renderNotificationBar` know not to run the plugin is installed interval.