### PR TITLE
AJS-283: Temp files for require("./utils") not found and requirejs async calls in webrtc/adapterjs browserified dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-include-replace');
     grunt.loadNpmTasks('grunt-karma');
     grunt.loadNpmTasks('grunt-githash');
+    grunt.loadNpmTasks('grunt-string-replace');
 
     grunt.initConfig({
 
@@ -240,6 +241,24 @@ module.exports = function(grunt) {
             'IE'
           ]
         }
+      },
+
+      // Replace the replace( module to prevent other require modules from referencing browserified file
+      'string-replace': {
+        dist: {
+          files: {
+            'publish/': 'publish/*.js'
+          },
+          options: {
+            replacements: [{
+              pattern: /\(require,/ig,
+              replacement: '(requirecopy,'
+            }, {
+              pattern: /require\(/ig,
+              replacement: 'requirecopy('
+            }]
+          }
+        }
       }
     });
 
@@ -346,6 +365,7 @@ module.exports = function(grunt) {
         'concat',
         'replace',
         'includereplace',
+        'string-replace',
         'uglify',
         'yuidoc'
     ]);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "grunt-include-replace": "^3.2.0",
     "grunt-karma": "^0.12.0",
     "grunt-replace": "0.7.9",
+    "grunt-string-replace": "^1.3.1",
     "karma": "^0.13.2",
     "karma-cdash-reporter": "^0.1.0",
     "karma-chai": "0.1.0",

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1,11 +1,6 @@
 // Adapter's interface.
 var AdapterJS = AdapterJS || {};
 
-// Browserify compatibility
-if(typeof exports !== 'undefined') {
-  module.exports = AdapterJS;
-}
-
 AdapterJS.options = AdapterJS.options || {};
 
 // uncomment to get virtual webcams
@@ -41,6 +36,13 @@ AdapterJS._onwebrtcreadies = [];
 AdapterJS.webRTCReady = function (callback) {
   if (typeof callback !== 'function') {
     throw new Error('Callback provided is not a function');
+  }
+
+  // Make users having requirejs to use the webRTCReady function to define first
+  // When you set a setTimeout(definePolyfill, 0), it overrides the WebRTC function
+  // This is be more than 0s
+  if (typeof window.require === 'function') {
+    AdapterJS.defineMediaSourcePolyfill();
   }
 
   if (true === AdapterJS.onwebrtcreadyDone) {
@@ -1399,4 +1401,11 @@ if ( (navigator.mozGetUserMedia ||
 
   // END OF WEBRTC PLUGIN SHIM
   ///////////////////////////////////////////////////////////////////
+}
+
+// Placed it here so that the module.exports from the browserified
+//   adapterjs will not override our AdapterJS exports
+// Browserify compatibility
+if(typeof exports !== 'undefined') {
+  module.exports = AdapterJS;
 }

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -43,8 +43,7 @@ AdapterJS.webRTCReady = function (baseCallback) {
     // When you set a setTimeout(definePolyfill, 0), it overrides the WebRTC function
     // This is be more than 0s
     if (typeof window.require === 'function' &&
-      typeof AdapterJS.defineMediaSourcePolyfill === 'function' &&
-      ) {
+      typeof AdapterJS.defineMediaSourcePolyfill === 'function') {
       AdapterJS.defineMediaSourcePolyfill();
     }
 

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -33,21 +33,29 @@ AdapterJS._onwebrtcreadies = [];
 // Sets a callback function to be called when the WebRTC interface is ready.
 // The first argument is the function to callback.\
 // Throws an error if the first argument is not a function
-AdapterJS.webRTCReady = function (callback) {
-  if (typeof callback !== 'function') {
+AdapterJS.webRTCReady = function (baseCallback) {
+  if (typeof baseCallback !== 'function') {
     throw new Error('Callback provided is not a function');
   }
 
-  // Make users having requirejs to use the webRTCReady function to define first
-  // When you set a setTimeout(definePolyfill, 0), it overrides the WebRTC function
-  // This is be more than 0s
-  if (typeof window.require === 'function') {
-    AdapterJS.defineMediaSourcePolyfill();
-  }
+  var callback = function () {
+    // Make users having requirejs to use the webRTCReady function to define first
+    // When you set a setTimeout(definePolyfill, 0), it overrides the WebRTC function
+    // This is be more than 0s
+    if (typeof window.require === 'function' &&
+      typeof AdapterJS.defineMediaSourcePolyfill === 'function' &&
+      ) {
+      AdapterJS.defineMediaSourcePolyfill();
+    }
+
+    // All WebRTC interfaces are ready, just call the callback
+    baseCallback(null !== AdapterJS.WebRTCPlugin.plugin);
+  };
+
+
 
   if (true === AdapterJS.onwebrtcreadyDone) {
-    // All WebRTC interfaces are ready, just call the callback
-    callback(null !== AdapterJS.WebRTCPlugin.plugin);
+    callback();
   } else {
     // will be triggered automatically when your browser/plugin is ready.
     AdapterJS._onwebrtcreadies.push(callback);

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -1,16 +1,13 @@
-(function () {
+AdapterJS.TEXT.EXTENSION = {
+  REQUIRE_INSTALLATION_FF: 'To enable screensharing you need to install the Skylink WebRTC tools Firefox Add-on.',
+  REQUIRE_INSTALLATION_CHROME: 'To enable screensharing you need to install the Skylink WebRTC tools Chrome Extension.',
+  REQUIRE_REFRESH: 'Please refresh this page after the Skylink WebRTC tools extension has been installed.',
+  BUTTON_FF: 'Install Now',
+  BUTTON_CHROME: 'Go to Chrome Web Store'
+};
 
-  'use strict';
-
+AdapterJS.defineMediaSourcePolyfill = function () {
   var baseGetUserMedia = null;
-
-  AdapterJS.TEXT.EXTENSION = {
-    REQUIRE_INSTALLATION_FF: 'To enable screensharing you need to install the Skylink WebRTC tools Firefox Add-on.',
-    REQUIRE_INSTALLATION_CHROME: 'To enable screensharing you need to install the Skylink WebRTC tools Chrome Extension.',
-    REQUIRE_REFRESH: 'Please refresh this page after the Skylink WebRTC tools extension has been installed.',
-    BUTTON_FF: 'Install Now',
-    BUTTON_CHROME: 'Go to Chrome Web Store'
-  };
 
   var clone = function(obj) {
     if (null === obj || 'object' !== typeof obj) {
@@ -233,4 +230,8 @@
   } else if (window.webrtcDetectedBrowser === 'opera') {
     console.warn('Opera does not support screensharing feature in getUserMedia');
   }
-})();
+};
+
+if (typeof window.require !== 'function') {
+  AdapterJS.defineMediaSourcePolyfill();
+}


### PR DESCRIPTION
This should fix #238 for now.

Currently while we look into make AdapterJS handle the browserify issues with webrtc/adapter dependency when we have the time, this temp fixes if it doesn't cause any issues should resolve the issue:

- Replace the `require(` to `requirecopy(` in the browserified file.
- Since `AdapterJS.webRTCReady()` is required initialization method to be invoked, define the screensharing overrides if requirejs module is defined.

Tested on:
- SkylinkJS tape tests which has the `require("./utils")` not found error and it works.
- SkylinkJS demo that doesn't use requirejs and it works.
- SkylinkJS getaroom.io demo and it works, the screensharing polyfills were called.