### PR TITLE
AJS-284 : Enable using mediaSource for screensharing with the plugin.

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1112,7 +1112,11 @@ if ( (navigator.mozGetUserMedia ||
       }
       var cc = {};
       Object.keys(c).forEach(function(key) {
-        if (key === 'require' || key === 'advanced' || key === 'mediaSource') {
+        if (key === 'require' || key === 'advanced') {
+          return;
+        }
+        if (typeof c[key] === 'string') {
+          cc[key] = c[key];
           return;
         }
         var r = (typeof c[key] === 'object') ? c[key] : {ideal: c[key]};

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -194,18 +194,17 @@ AdapterJS.defineMediaSourcePolyfill = function () {
         // wait for plugin to be ready
         AdapterJS.WebRTCPlugin.callWhenPluginReady(function() {
           // check if screensharing feature is available
-          if (!!AdapterJS.WebRTCPlugin.plugin.HasScreensharingFeature &&
-            !!AdapterJS.WebRTCPlugin.plugin.isScreensharingAvailable) {
-            // set the constraints
+          if ( !AdapterJS.WebRTCPlugin.plugin.HasScreensharingFeature
+            || !AdapterJS.WebRTCPlugin.plugin.isScreensharingAvailable ) {
+            failureCb(new Error('Your version of the WebRTC plugin does not support screensharing'));
+            return;
+          } else if (typeof AdapterJS.WebRTCPlugin.plugin.screensharingKeys === 'undefined') {
+            // Legacy system, set the sourceId to AdapterJS.WebRTCPlugin.plugin.screensharingKey
             updatedConstraints.video.optional = updatedConstraints.video.optional || [];
             updatedConstraints.video.optional.push({
               sourceId: AdapterJS.WebRTCPlugin.plugin.screensharingKey || 'Screensharing'
             });
-
             delete updatedConstraints.video.mediaSource;
-          } else {
-            failureCb(new Error('Your version of the WebRTC plugin does not support screensharing'));
-            return;
           }
           baseGetUserMedia(updatedConstraints, successCb, failureCb);
         });


### PR DESCRIPTION
These modifications allow to set a specific key as a mediaSource to filter for screen only, window only, or both.

These behaviour requires a plugin v0.8.891 or higher (```AdapterJS.WebRTCPlugin.plugin.screensharingKeys```) defined.
Otherwise, it will default to the current behaviour.