### PR TITLE
Use native RTCPeerConnection API when available for Edge browsers on Windows Creator Update

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -612,6 +612,11 @@ if ( (navigator.mozGetUserMedia ||
   ///////////////////////////////////////////////////////////////////
   // INJECTION OF GOOGLE'S ADAPTER.JS CONTENT
 
+  // Prevent Edge overrides
+  if (navigator.userAgent.match(/Edge\/(\d+).(\d+)$/) && window.RTCPeerConnection) {
+    window.cachedRTCPeerConnection = window.RTCPeerConnection;
+  }
+
 /* jshint ignore:start */
 @Goo@include('third_party/adapter/out/adapter.js', {})
 /* jshint ignore:end */
@@ -771,6 +776,10 @@ if ( (navigator.mozGetUserMedia ||
       to.srcObject = from.srcObject;
       return to;
     };
+
+    if (window.cachedRTCPeerConnection) {
+      window.RTCPeerConnection = window.cachedRTCPeerConnection;
+    }
   }
 
   // Need to override attachMediaStream and reattachMediaStream

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -612,9 +612,9 @@ if ( (navigator.mozGetUserMedia ||
   ///////////////////////////////////////////////////////////////////
   // INJECTION OF GOOGLE'S ADAPTER.JS CONTENT
 
-  // Prevent Edge overrides
+  // Store the original native RTCPC in msRTCPeerConnection object
   if (navigator.userAgent.match(/Edge\/(\d+).(\d+)$/) && window.RTCPeerConnection) {
-    window.cachedRTCPeerConnection = window.RTCPeerConnection;
+    window.msRTCPeerConnection = window.RTCPeerConnection;
   }
 
 /* jshint ignore:start */
@@ -776,10 +776,6 @@ if ( (navigator.mozGetUserMedia ||
       to.srcObject = from.srcObject;
       return to;
     };
-
-    if (window.cachedRTCPeerConnection) {
-      window.RTCPeerConnection = window.cachedRTCPeerConnection;
-    }
   }
 
   // Need to override attachMediaStream and reattachMediaStream


### PR DESCRIPTION
- The latest version of `webrtc/adapter` uses the ORTC polyfill still, which doesn't work on the latest Edge browsers on Windows Creator Update. Since RTCPeerConnection API is available, there's no need for polyfills.
- This should prevent any overrides from the `webrtc/adapter`.
