### PR TITLE
AJS-261: Extensions upgrade and allowing configuration of extensions from AdapterJS level

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,14 @@ AdapterJS `0.12.0`+ offers cross-browser screensharing in Chrome `34`+, Firefox 
 
 To use the screensharing functionality, reference `publish/adapter.screenshare.js` and add the `mediaSource: 'window'` setting to the video media constraints. This requires HTTPS!
 
+Note that the the `mediaSource` property takes in String, or Array in which multiple sources is supported for Chrome / Opera sources. For Firefox, if an Array is provided, it takes the first item in the Array.
+
 **Example:**
 
 ```javascript
 window.navigator.getUserMedia({
   video: {
-    mediaSource: 'window' || 'screen'
+    mediaSource: 'window' || 'screen' || ['tab', 'audio'] || ['window' || 'screen']
   }
 }, function (stream) {
   console.log('Received stream', stream);

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AdapterJS provides polyfills and cross-browser helpers for WebRTC. It wraps arou
 | Browsers          | Min. Version | OS Platform              | Screensharing             | 
 | ----------------- | ------------ | ------------------------ | ------------------------- | 
 | Chrome \ Chromium | `38`         | MacOS / Win / Ubuntu / Android | Yes (w [Extension](https://chrome.google.com/webstore/detail/skylink-webrtc-tools/ljckddiekopnnjoeaiofddfhgnbdoafc))         |
-| Firefox           | `33`         | MacOS / Win / Ubuntu / Android | Yes (w [Extension](https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/))         |
+| Firefox           | `33`         | MacOS / Win / Ubuntu / Android | Yes (w [Extension for `51` and below](https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/))         |
 | Opera             | `26`         | MacOS / Win / Ubuntu / Android |  -                        | 
 | Edge              | `13.10547`^  | Win                      |  -                        |
 | Bowser            | `0.6.1`      | iOS 9.x only**           |  -                        |

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1185,7 +1185,11 @@ if ( (navigator.mozGetUserMedia ||
       typeof Promise !== 'undefined') {
       requestUserMedia = function(constraints) {
         return new Promise(function(resolve, reject) {
-          getUserMedia(constraints, resolve, reject);
+          try {
+            getUserMedia(constraints, resolve, reject);
+          } catch (error) {
+            reject(error);
+          }
         });
       };
       navigator.mediaDevices = {getUserMedia: requestUserMedia,

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -43,8 +43,8 @@ AdapterJS.webRTCReady = function (baseCallback) {
     // When you set a setTimeout(definePolyfill, 0), it overrides the WebRTC function
     // This is be more than 0s
     if (typeof window.require === 'function' &&
-      typeof AdapterJS.defineMediaSourcePolyfill === 'function') {
-      AdapterJS.defineMediaSourcePolyfill();
+      typeof AdapterJS._defineMediaSourcePolyfill === 'function') {
+      AdapterJS._defineMediaSourcePolyfill();
     }
 
     // All WebRTC interfaces are ready, just call the callback

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -12,9 +12,7 @@ AdapterJS.extensionInfo =  AdapterJS.extensionInfo || {
   chrome: {
     extensionId: 'ljckddiekopnnjoeaiofddfhgnbdoafc',
     extensionLink: 'https://chrome.google.com/webstore/detail/skylink-webrtc-tools/ljckddiekopnnjoeaiofddfhgnbdoafc',
-    // Flag for extension versions that does not honor the "mediaSource" flag
-    legacy: true,
-    // Deprecated! Define this to use iframe method
+    // Deprecated! Define this to use iframe method that works with previous extension codebase that does not honor "mediaSource" flag
     iframeLink: 'https://cdn.temasys.com.sg/skylink/extensions/detectRTC.html'
   },
   // Required only for Firefox 51 and below
@@ -430,7 +428,7 @@ AdapterJS._defineMediaSourcePolyfill = function () {
         iframe.contentWindow.postMessage({
           captureSourceId: true,
           sources: sources,
-          legacy: AdapterJS.extensionInfo.chrome.legacy,
+          legacy: true,
           extensionId: AdapterJS.extensionInfo.chrome.extensionId,
           extensionLink: AdapterJS.extensionInfo.chrome.extensionLink
         }, '*');

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -529,6 +529,8 @@ AdapterJS._defineMediaSourcePolyfill = function () {
             updatedConstraints.video.optional = updatedConstraints.video.optional || [];
             updatedConstraints.video.optional.push({ sourceId: sourceId });
 
+            // TODO: Should we even remove the "mediaSource" flag actually?
+            // Keeping this for now as borrowing off previous logic to prevent breaking anything
             if ([AdapterJS.WebRTCPlugin.plugin.screensharingKey, 'Screensharing'].indexOf(sourceId) > -1) {
               delete updatedConstraints.video.mediaSource;
             }

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -161,6 +161,24 @@ AdapterJS.defineMediaSourcePolyfill = function () {
         // See: https://developer.chrome.com/extensions/desktopCapture#type-DesktopCaptureSourceType
         var mediaSourcesList = ['window', 'screen', 'tab', 'audio'];
 
+        // Check if it is Android phone for experimental 59 screensharing
+        // See: https://bugs.chromium.org/p/chromium/issues/detail?id=487935
+        if (navigator.userAgent.toLowerCase().indexOf('android') > -1) {
+          if (Array.isArray(updatedConstraints.video.mediaSource) ?
+            updatedConstraints.video.mediaSource.indexOf('screen') > -1 :
+            updatedConstraints.video.mediaSource === 'screen') {
+            updatedConstraints.video.mandatory = updatedConstraints.video.mandatory || {};
+            updatedConstraints.video.mandatory.chromeMediaSource = 'screen';
+            updatedConstraints.video.mandatory.maxHeight = window.screen.height;
+            updatedConstraints.video.mandatory.maxWidth = window.screen.width;
+            delete updatedConstraints.video.mediaSource;
+            baseGetUserMedia(updatedConstraints, successCb, failureCb);
+          } else {
+            failureCb(new Error('GetUserMedia: Only "screen" are supported as mediaSource constraints for Android'));
+          }
+          return;
+        }
+
         // Check against non valid sources
         if (typeof updatedConstraints.video.mediaSource === 'string' &&
           mediaSourcesList.indexOf(updatedConstraints.video.mediaSource) > -1 &&

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -12,7 +12,9 @@ AdapterJS.extensionInfo = {
   chrome: {
     extensionId: 'ljckddiekopnnjoeaiofddfhgnbdoafc',
     extensionLink: 'https://chrome.google.com/webstore/detail/skylink-webrtc-tools/ljckddiekopnnjoeaiofddfhgnbdoafc',
-    // Define this to use iframe method
+    // Flag for extension versions that does not honor the "mediaSource" flag
+    legacy: true,
+    // Deprecated! Define this to use iframe method
     iframeLink: 'https://cdn.temasys.com.sg/skylink/extensions/detectRTC.html',
     // Invoke this again if AdapterJS.extensionInfo is defined later with a different iframeLink
     reloadIFrame: null
@@ -397,6 +399,7 @@ AdapterJS.defineMediaSourcePolyfill = function () {
         iframe.contentWindow.postMessage({
           captureSourceId: true,
           sources: sources,
+          legacy: AdapterJS.extensionInfo.chrome.legacy,
           extensionId: AdapterJS.extensionInfo.chrome.extensionId,
           extensionLink: AdapterJS.extensionInfo.chrome.extensionLink
         }, '*');

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -54,7 +54,8 @@ AdapterJS.defineMediaSourcePolyfill = function () {
       }
 
       // Prevent accessing property from Boolean errors
-      if (constraints.video && typeof constraints.video === 'object' && constraints.video.hasOwnProperty('mediaSource')) {
+      if (constraints.video && typeof constraints.video === 'object' &&
+        constraints.video.hasOwnProperty('mediaSource')) {
         var updatedConstraints = clone(constraints);
 
         // Obtain first item in array if array is provided
@@ -150,14 +151,19 @@ AdapterJS.defineMediaSourcePolyfill = function () {
           return;
         }
 
+        var updatedConstraints = clone(constraints);
+
         // Check against non "screen" or "window"
-        if (!(['window', 'screen', 'tab'].indexOf(constraints.video.mediaSource) > -1 ||
+        if (!(['window', 'screen', 'tab'].indexOf(updatedConstraints.video.mediaSource) > -1 ||
         // Check against Array not containing either - ["tab", "window", "screen"]
-          (Array.isArray(constraints.video.mediaSource) && (constraints.video.mediaSource.indexOf('window') > -1 ||
-          constraints.video.mediaSource.indexOf('screen') > -1 || constraints.video.mediaSource.indexOf('tab') > -1)))) {
+          (Array.isArray(updatedConstraints.video.mediaSource) &&
+          (updatedConstraints.video.mediaSource.indexOf('window') > -1 ||
+          updatedConstraints.video.mediaSource.indexOf('screen') > -1 ||
+          updatedConstraints.video.mediaSource.indexOf('tab') > -1)))) {
           // Check against returning "audio" or ["audio"] without "tab"
-          if (Array.isArray(constraints.video.mediaSource) ? constraints.video.mediaSource.indexOf('audio') > -1 :
-            constraints.video.mediaSource === 'audio') {
+          if (Array.isArray(updatedConstraints.video.mediaSource) ?
+            updatedConstraints.video.mediaSource.indexOf('audio') > -1 :
+            updatedConstraints.video.mediaSource === 'audio') {
             failureCb(new Error('GetUserMedia: "audio" mediaSource must be provided with ["audio", "tab"]'));
           } else {
             failureCb(new Error('GetUserMedia: Only "screen", "window", "tab" are supported as mediaSource constraints'));
@@ -165,10 +171,13 @@ AdapterJS.defineMediaSourcePolyfill = function () {
           return;
         }
 
-        if (Array.isArray(constraints.video.mediaSource) && constraints.video.mediaSource.indexOf('tab') > -1 &&
-          constraints.video.mediaSource.indexOf('audio') > -1 && !update)
+        // Warn users that no tab audio will be used because constraints.audio must be enabled
+        if (Array.isArray(updatedConstraints.video.mediaSource) &&
+          updatedConstraints.video.mediaSource.indexOf('tab') > -1 &&
+          updatedConstraints.video.mediaSource.indexOf('audio') > -1 && !updatedConstraints.audio) {
+          console.warn('Audio must be requested if "tab" and "audio" mediaSource constraints is requested');
+        }
 
-        var updatedConstraints = clone(constraints);
         var fetchStream = function (response) {
           if (response.success) {
             updatedConstraints.video.mandatory = updatedConstraints.video.mandatory || {};

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -27,7 +27,16 @@ AdapterJS.extensionInfo =  AdapterJS.extensionInfo || {
   }
 };
 
+AdapterJS._mediaSourcePolyfillIsDefined = false;
+
 AdapterJS.defineMediaSourcePolyfill = function () {
+  // Insanity checks to prevent re-defining the polyfills again in any case.
+  if (AdapterJS._mediaSourcePolyfillIsDefined) {
+    return;
+  }
+
+  AdapterJS._mediaSourcePolyfillIsDefined = true;
+
   var baseGetUserMedia = null;
 
   var clone = function(obj) {

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -49,19 +49,23 @@ AdapterJS._defineMediaSourcePolyfill = function () {
     return copy;
   };
 
+  var checkIfConstraintsIsValid = function (constraints, successCb, failureCb) {
+    // Append checks for overrides as these are mandatory
+    // Browsers (not Firefox since they went Promise based) does these checks and they can be quite useful
+    if (!(constraints && typeof constraints === 'object')) {
+      throw new Error('GetUserMedia: (constraints, .., ..) argument required');
+    } else if (typeof successCb !== 'function') {
+      throw new Error('GetUserMedia: (.., successCb, ..) argument required');
+    } else if (typeof failureCb !== 'function') {
+      throw new Error('GetUserMedia: (.., .., failureCb) argument required');
+    }
+  };
+
   if (window.navigator.mozGetUserMedia) {
     baseGetUserMedia = window.navigator.getUserMedia;
 
     navigator.getUserMedia = function (constraints, successCb, failureCb) {
-      // Append checks for overrides as these are mandatory
-      // Browsers (not Firefox since they went Promise based) does these checks and they can be quite useful
-      if (!(constraints && typeof constraints === 'object')) {
-        throw new Error('GetUserMedia: (constraints, .., ..) argument required');
-      } else if (typeof successCb !== 'function') {
-        throw new Error('GetUserMedia: (.., successCb, ..) argument required');
-      } else if (typeof failureCb !== 'function') {
-        throw new Error('GetUserMedia: (.., .., failureCb) argument required');
-      }
+      checkIfConstraintsIsValid(constraints, successCb, failureCb);
 
       // Prevent accessing property from Boolean errors
       if (constraints.video && typeof constraints.video === 'object' &&
@@ -149,15 +153,7 @@ AdapterJS._defineMediaSourcePolyfill = function () {
     var iframe = document.createElement('iframe');
 
     navigator.getUserMedia = function (constraints, successCb, failureCb) {
-      // Append checks for overrides as these are mandatory
-      // Browsers (not Firefox since they went Promise based) does these checks and they can be quite useful
-      if (!(constraints && typeof constraints === 'object')) {
-        throw new Error('GetUserMedia: (constraints, .., ..) argument required');
-      } else if (typeof successCb !== 'function') {
-        throw new Error('GetUserMedia: (.., successCb, ..) argument required');
-      } else if (typeof failureCb !== 'function') {
-        throw new Error('GetUserMedia: (.., .., failureCb) argument required');
-      }
+      checkIfConstraintsIsValid(constraints, successCb, failureCb);
 
       // Prevent accessing property from Boolean errors
       if (constraints.video && typeof constraints.video === 'object' && constraints.video.hasOwnProperty('mediaSource')) {
@@ -483,15 +479,7 @@ AdapterJS._defineMediaSourcePolyfill = function () {
     baseGetUserMedia = window.navigator.getUserMedia;
 
     navigator.getUserMedia = function (constraints, successCb, failureCb) {
-      // Append checks for overrides as these are mandatory
-      // Browsers (not Firefox since they went Promise based) does these checks and they can be quite useful
-      if (!(constraints && typeof constraints === 'object')) {
-        throw new Error('GetUserMedia: (constraints, .., ..) argument required');
-      } else if (typeof successCb !== 'function') {
-        throw new Error('GetUserMedia: (.., successCb, ..) argument required');
-      } else if (typeof failureCb !== 'function') {
-        throw new Error('GetUserMedia: (.., .., failureCb) argument required');
-      }
+      checkIfConstraintsIsValid(constraints, successCb, failureCb);
 
       if (constraints.video && typeof constraints.video === 'object' && constraints.video.hasOwnProperty('mediaSource')) {
         var updatedConstraints = clone(constraints);

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -487,7 +487,7 @@ AdapterJS._defineMediaSourcePolyfill = function () {
         throw new Error('GetUserMedia: (.., .., failureCb) argument required');
       }
 
-      if (constraints.video && typeof constraints.video === 'string' && constraints.video.hasOwnProperty('mediaSource')) {
+      if (constraints.video && typeof constraints.video === 'object' && constraints.video.hasOwnProperty('mediaSource')) {
         var updatedConstraints = clone(constraints);
 
         // Wait for plugin to be ready

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -14,6 +14,7 @@ AdapterJS.extensionInfo = {
     extensionLink: 'https://chrome.google.com/webstore/detail/skylink-webrtc-tools/ljckddiekopnnjoeaiofddfhgnbdoafc',
     iframeLink: 'https://cdn.temasys.com.sg/skylink/extensions/detectRTC.html',
   },
+  // Required only for Firefox 51 and below
   firefox: {
     extensionLink: 'https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/'
   }
@@ -61,7 +62,8 @@ AdapterJS.defineMediaSourcePolyfill = function () {
             clearInterval(checkIfReady);
 
             baseGetUserMedia(updatedConstraints, successCb, function (error) {
-              if (['NotAllowedError', 'PermissionDeniedError', 'SecurityError', 'NotAllowedError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
+              if (['NotAllowedError', 'PermissionDeniedError', 'SecurityError', 'NotAllowedError'].indexOf(error.name) > -1 &&
+                window.parent.location.protocol === 'https:' && window.webrtcDetectedVersion < 52) {
                 AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_FF,
                   AdapterJS.TEXT.EXTENSION.BUTTON_FF, function (e) {
                   window.open(AdapterJS.extensionInfo.firefox.extensionLink, '_blank');

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -529,12 +529,6 @@ AdapterJS._defineMediaSourcePolyfill = function () {
             updatedConstraints.video.optional = updatedConstraints.video.optional || [];
             updatedConstraints.video.optional.push({ sourceId: sourceId });
 
-            // TODO: Should we even remove the "mediaSource" flag actually?
-            // Keeping this for now as borrowing off previous logic to prevent breaking anything
-            if ([AdapterJS.WebRTCPlugin.plugin.screensharingKey, 'Screensharing'].indexOf(sourceId) > -1) {
-              delete updatedConstraints.video.mediaSource;
-            }
-
             baseGetUserMedia(updatedConstraints, successCb, failureCb);
 
           } else {

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -470,38 +470,7 @@ AdapterJS.defineMediaSourcePolyfill = function () {
     }
 
   } else if (navigator.mediaDevices && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) {
-    baseGetUserMedia = window.navigator.getUserMedia;
-
-    navigator.getUserMedia = function (constraints, successCb, failureCb) {
-      // Append checks for overrides as these are mandatory
-      // Browsers (not Firefox since they went Promise based) does these checks and they can be quite useful
-      if (!(constraints && typeof constraints === 'object')) {
-        throw new Error('GetUserMedia: (constraints, .., ..) argument required');
-      } else if (typeof successCb !== 'function') {
-        throw new Error('GetUserMedia: (.., successCb, ..) argument required');
-      } else if (typeof failureCb !== 'function') {
-        throw new Error('GetUserMedia: (.., .., failureCb) argument required');
-      }
-
-      if (constraints.video && typeof constraints.video === 'string' && constraints.video.hasOwnProperty('mediaSource')) {
-        failureCb(new Error('Current browser does not support screensharing'));
-        return;
-      }
-
-      baseGetUserMedia(constraints, successCb, failureCb);
-    };
-
-    AdapterJS.getUserMedia = window.getUserMedia = navigator.getUserMedia;
-    navigator.mediaDevices.getUserMedia = function(constraints) {
-      return new Promise(function(resolve, reject) {
-        try {
-          window.getUserMedia(constraints, resolve, reject);
-        } catch (error) {
-          reject(error);
-        }
-      });
-    };
-
+    // Note: Not overriding getUserMedia() to reject "mediaSource" as to prevent "Invalid calling object" errors.
     // Nothing here because edge does not support screensharing
     console.warn('Edge does not support screensharing feature in getUserMedia');
 

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -185,6 +185,16 @@ AdapterJS.defineMediaSourcePolyfill = function () {
             updatedConstraints.video.mandatory.maxWidth = window.screen.width > 1920 ? window.screen.width : 1920;
             updatedConstraints.video.mandatory.maxHeight = window.screen.height > 1080 ? window.screen.height : 1080;
             updatedConstraints.video.mandatory.chromeMediaSourceId = response.sourceId;
+
+            if (Array.isArray(updatedConstraints.video.mediaSource) &&
+              updatedConstraints.video.mediaSource.indexOf('tab') > -1 &&
+              updatedConstraints.video.mediaSource.indexOf('audio') > -1 && updatedConstraints.audio) {
+              updatedConstraints.audio = typeof updatedConstraints.audio === 'object' ? updatedConstraints.audio : {};
+              updatedConstraints.audio.mandatory = updatedConstraints.audio.mandatory || {};
+              updatedConstraints.audio.mandatory.chromeMediaSource = 'desktop';
+              updatedConstraints.audio.mandatory.chromeMediaSourceId = response.sourceId;
+            }
+
             delete updatedConstraints.video.mediaSource;
             baseGetUserMedia(updatedConstraints, successCb, failureCb);
           } else {

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -178,7 +178,7 @@ AdapterJS.defineMediaSourcePolyfill = function () {
               }
               j++;
             }
-            index++;
+            i++;
           }
           updatedConstraints.video.mediaSource = outputMediaSource;
         } else {

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -86,7 +86,7 @@ AdapterJS._defineMediaSourcePolyfill = function () {
             updatedConstraints.video.mediaSource : null;
         }
 
-        // Invalid mediaSource for firefox, only "screen" and "window" are supported
+        // Invalid mediaSource for firefox, only specified sources are supported
         if (mediaSourcesList.indexOf(updatedConstraints.video.mediaSource) === -1) {
           failureCb(new Error('GetUserMedia: Only "screen" and "window" are supported as mediaSource constraints'));
           return;

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -1,9 +1,22 @@
+// Define extension popup bar text
 AdapterJS.TEXT.EXTENSION = {
   REQUIRE_INSTALLATION_FF: 'To enable screensharing you need to install the Skylink WebRTC tools Firefox Add-on.',
   REQUIRE_INSTALLATION_CHROME: 'To enable screensharing you need to install the Skylink WebRTC tools Chrome Extension.',
   REQUIRE_REFRESH: 'Please refresh this page after the Skylink WebRTC tools extension has been installed.',
   BUTTON_FF: 'Install Now',
   BUTTON_CHROME: 'Go to Chrome Web Store'
+};
+
+// Define extension settings
+AdapterJS.extensionInfo = {
+  chrome: {
+    extensionId: 'ljckddiekopnnjoeaiofddfhgnbdoafc',
+    extensionLink: 'https://chrome.google.com/webstore/detail/skylink-webrtc-tools/ljckddiekopnnjoeaiofddfhgnbdoafc',
+    iframeLink: 'https://cdn.temasys.com.sg/skylink/extensions/detectRTC.html',
+  },
+  firefox: {
+    extensionLink: 'https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/'
+  }
 };
 
 AdapterJS.defineMediaSourcePolyfill = function () {
@@ -51,7 +64,7 @@ AdapterJS.defineMediaSourcePolyfill = function () {
               if (['NotAllowedError', 'PermissionDeniedError', 'SecurityError', 'NotAllowedError'].indexOf(error.name) > -1 && window.parent.location.protocol === 'https:') {
                 AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_FF,
                   AdapterJS.TEXT.EXTENSION.BUTTON_FF, function (e) {
-                  window.open('https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/', '_blank');
+                  window.open(AdapterJS.extensionInfo.firefox.extensionLink, '_blank');
                   if (e.target && e.target.parentElement && e.target.nextElementSibling &&
                     e.target.nextElementSibling.click) {
                     e.target.nextElementSibling.click();
@@ -140,7 +153,7 @@ AdapterJS.defineMediaSourcePolyfill = function () {
             if (event.data.chromeExtensionStatus === 'not-installed') {
               AdapterJS.renderNotificationBar(AdapterJS.TEXT.EXTENSION.REQUIRE_INSTALLATION_CHROME,
                 AdapterJS.TEXT.EXTENSION.BUTTON_CHROME, function (e) {
-                window.open(event.data.data, '_blank');
+                window.open(AdapterJS.extensionInfo.chrome.extensionLink || event.data.data, '_blank');
                 if (e.target && e.target.parentElement && e.target.nextElementSibling &&
                   e.target.nextElementSibling.click) {
                   e.target.nextElementSibling.click();
@@ -164,7 +177,8 @@ AdapterJS.defineMediaSourcePolyfill = function () {
         window.addEventListener('message', onIFrameCallback);
 
         postFrameMessage({
-          captureSourceId: true
+          captureSourceId: true,
+          extensionId: AdapterJS.extensionInfo.chrome.extensionId
         });
 
       } else {
@@ -232,7 +246,7 @@ AdapterJS.defineMediaSourcePolyfill = function () {
       iframe.isLoaded = true;
     };
 
-    iframe.src = 'https://cdn.temasys.com.sg/skylink/extensions/detectRTC.html';
+    iframe.src = AdapterJS.extensionInfo.chrome.iframeLink;
     iframe.style.display = 'none';
 
     (document.body || document.documentElement).appendChild(iframe);

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -8,16 +8,14 @@ AdapterJS.TEXT.EXTENSION = {
 };
 
 // Define extension settings
-AdapterJS.extensionInfo = {
+AdapterJS.extensionInfo =  AdapterJS.extensionInfo || {
   chrome: {
     extensionId: 'ljckddiekopnnjoeaiofddfhgnbdoafc',
     extensionLink: 'https://chrome.google.com/webstore/detail/skylink-webrtc-tools/ljckddiekopnnjoeaiofddfhgnbdoafc',
     // Flag for extension versions that does not honor the "mediaSource" flag
     legacy: true,
     // Deprecated! Define this to use iframe method
-    iframeLink: 'https://cdn.temasys.com.sg/skylink/extensions/detectRTC.html',
-    // Invoke this again if AdapterJS.extensionInfo is defined later with a different iframeLink
-    reloadIFrame: null
+    iframeLink: 'https://cdn.temasys.com.sg/skylink/extensions/detectRTC.html'
   },
   // Required only for Firefox 51 and below
   firefox: {
@@ -336,9 +334,8 @@ AdapterJS.defineMediaSourcePolyfill = function () {
       });
     };
 
-    // Save the loading of iframe into a function so users can invoke this later when
-    //   the iframe settings is defined after AdapterJS is loaded.
-    AdapterJS.extensionInfo.chrome.reloadIFrame = function () {
+    // Start loading the iframe
+    if (window.webrtcDetectedBrowser === 'chrome') {
       var states = {
         loaded: false,
         error: false
@@ -462,11 +459,6 @@ AdapterJS.defineMediaSourcePolyfill = function () {
 
       // Re-append to reload
       (document.body || document.documentElement).appendChild(iframe);
-    };
-
-    // Start loading the iframe
-    if (window.webrtcDetectedBrowser === 'chrome') {
-      AdapterJS.extensionInfo.chrome.reloadIFrame();
     }
 
   } else if (navigator.mediaDevices && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) {

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -28,15 +28,13 @@ AdapterJS.extensionInfo =  AdapterJS.extensionInfo || {
 };
 
 AdapterJS._mediaSourcePolyfillIsDefined = false;
-
-AdapterJS.defineMediaSourcePolyfill = function () {
-  // Insanity checks to prevent re-defining the polyfills again in any case.
+AdapterJS._defineMediaSourcePolyfill = function () {
+  // Sanity checks to prevent re-defining the polyfills again in any case.
   if (AdapterJS._mediaSourcePolyfillIsDefined) {
     return;
   }
 
   AdapterJS._mediaSourcePolyfillIsDefined = true;
-
   var baseGetUserMedia = null;
 
   var clone = function(obj) {
@@ -543,5 +541,5 @@ AdapterJS.defineMediaSourcePolyfill = function () {
 };
 
 if (typeof window.require !== 'function') {
-  AdapterJS.defineMediaSourcePolyfill();
+  AdapterJS._defineMediaSourcePolyfill();
 }

--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -195,6 +195,37 @@ AdapterJS.defineMediaSourcePolyfill = function () {
       });
     };
 
+    // For chrome, use an iframe to load the screensharing extension
+    // in the correct domain.
+    // Modify here for custom screensharing extension in chrome
+    if (window.webrtcDetectedBrowser === 'chrome') {
+      var iframe = document.createElement('iframe');
+
+      iframe.onload = function() {
+        iframe.isLoaded = true;
+      };
+
+      iframe.src = AdapterJS.extensionInfo.chrome.iframeLink;
+      iframe.style.display = 'none';
+
+      (document.body || document.documentElement).appendChild(iframe);
+
+      var postFrameMessage = function (object) { // jshint ignore:line
+        object = object || {};
+
+        if (!iframe.isLoaded) {
+          setTimeout(function () {
+            iframe.contentWindow.postMessage(object, '*');
+          }, 100);
+          return;
+        }
+
+        iframe.contentWindow.postMessage(object, '*');
+      };
+    } else if (window.webrtcDetectedBrowser === 'opera') {
+      console.warn('Opera does not support screensharing feature in getUserMedia');
+    }
+
   } else if (navigator.mediaDevices && navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) {
     // nothing here because edge does not support screensharing
     console.warn('Edge does not support screensharing feature in getUserMedia');
@@ -236,37 +267,6 @@ AdapterJS.defineMediaSourcePolyfill = function () {
       typeof Promise !== 'undefined') {
       navigator.mediaDevices.getUserMedia = requestUserMedia;
     }
-  }
-
-  // For chrome, use an iframe to load the screensharing extension
-  // in the correct domain.
-  // Modify here for custom screensharing extension in chrome
-  if (window.webrtcDetectedBrowser === 'chrome') {
-    var iframe = document.createElement('iframe');
-
-    iframe.onload = function() {
-      iframe.isLoaded = true;
-    };
-
-    iframe.src = AdapterJS.extensionInfo.chrome.iframeLink;
-    iframe.style.display = 'none';
-
-    (document.body || document.documentElement).appendChild(iframe);
-
-    var postFrameMessage = function (object) { // jshint ignore:line
-      object = object || {};
-
-      if (!iframe.isLoaded) {
-        setTimeout(function () {
-          iframe.contentWindow.postMessage(object, '*');
-        }, 100);
-        return;
-      }
-
-      iframe.contentWindow.postMessage(object, '*');
-    };
-  } else if (window.webrtcDetectedBrowser === 'opera') {
-    console.warn('Opera does not support screensharing feature in getUserMedia');
   }
 };
 


### PR DESCRIPTION
> **Note**: <s>New extensions must be approved first, and then the ID and links can be updated to this branch before this PR can be merged. Additionally</s> this blocks the release of [ESS-886](https://jira.temasys.com.sg/browse/ESS-886) since it is tested with this branch.

# **Summary**
This PR is to patch Chrome/IE/Safari `"mediaSource"` flag not being honoured, and realised that an entire extension update has to be done. This is for us to ensure our polyfills and extensions are up-to-date as of what's the current state of things in implementations. This PR might have huge code changes.

Note that we are not waiting for the extensions to be approved due to time constraints, that will be another mini PR for that.

# **Changelog:**
- Added `AdapterJS.extensionInfo` object to allow configuration of custom extension using the AdapterJS extension codebase. Developers can override the extension settings by pre-defining the `AdapterJS` object first then loading the `AdapterJS` script.
  
  **Example:**

  ```
   <script>
      var AdapterJS = {};
      AdapterJS.extensionInfo = { ... };
      AdapterJS.options = { ... };
      AdapterJS.pluginInfo = { ... };
   </script>
   <script src="https://cdn.temasys.com.sg/adapterjs/0.14.x/adapter.screenshare.js"></script>
   <script>
      AdapterJS.webRTCReady(function () { /* Start using getUserMedia() and RTCPeerConnection */ });
   </script>
  ```

- Removed required need to install Firefox addon for version `52` and above.
  1. Previously, we require an addon which uses the Bootstrapped API, which allows modification of the browser preferences of `media.getusermedia.screensharing.enabled` to enable screensharing and `media.getusermedia.screensharing.allowed_domains`) to whitelist the domains.

  2. However, `media.getusermedia.screensharing.enabled` has been enabled by default and whitelisting has been [removed from `52` onwards](https://wiki.mozilla.org/Screensharing).

  3. Even so, the Bootstrapped API [no longer can be used](https://developer.mozilla.org/en-US/Add-ons/Bootstrapped_extensions) from `53` onwards and uploaded on the [addons.mozilla.org (AMO)](addons.mozilla.org).
  
  4. The extension we have - [Skylink WebRTC Tools](https://addons.mozilla.org/en-US/firefox/addon/skylink-webrtc-tools/) will work with `51` and below and only with our specified domains.

  5. If developers need to enable screensharing for `51` and below, we have to ask them to tell their end-users to modify the `about:config` manually and set the `media.getusermedia.screensharing.enabled` to `true` and `media.getusermedia.screensharing.allowed_domains` to append the domain they want to enable screensharing.

- Added checks to ensure that required and correct parameters are provided.

  - `navigator.getUserMedia()` should receive parameters like `constraints`, `successCb` and `failureCb`, else throw an `Error`.

  - Due to the overrides, when we need to return `failureCb()` for extension disabled case, it will throw an `Error` with message like "failureCb() is not a method" which instead we could tell the users to provide the correct mandatory parameters first.

  - Browsers generally throw errors if parameters are not satisfied. Try `navigator.mozGetUserMedia({})` or `navigator.webkitGetUserMedia({})` and errors should be thrown.

  - Implemented `try` and `catch` for  `navigator.mediaDevices.getUserMedia()` which returns a `Promise` to prevent the `Error` when thrown to be returned in `Promise`'s `reject` as part of the `Promise` methodology.

- Added stringent checks to ensure the types are expected. 
 
   - Example, instead of `object && !!object.prop`, do this `object && typeof object === 'object' && object.hasOwnProperty(prop)`.

   - Older Firefox versions used to give me this when implementing a similar login in the SDK: "Read a property from a non-object but a Boolean" errors before, it's better to add checks with expected types.

- Fixes to honour the `"mediaSource"` flag in Chrome / Safari / IE / Firefox.

   - Updated Chrome extensions and detectRTC.html code base to ensure that `"mediaSource"` flag is honoured. The codebase should be able to be backwards compatible.

   - When `"mediaSource"` flag is provided in Safari / IE, [accept only values](https://confluence.temasys.com.sg/display/TWT/Screensharing) like `"screen"`, `"window"` or a combination of them in an `Array`.

     - When `AdapterJS.WebRTCPlugin.plugin.screensharingKeys` is not available, fallback to alternative like `AdapterJS.WebRTCPlugin.plugin.screensharingKey || "Screensharing"`.

  - When `"mediaSource"` flag is provided in Chrome / Opera, [accept only values](https://developer.chrome.com/extensions/desktopCapture#type-DesktopCaptureSourceType) like `"screen"`, `"window"`, `"tab"` or a combination of them in an `Array`.

    - Additionally accept only types like `["tab", "audio"]` to retrieve tab audio. If `constraints.audio` is not enabled (truthy) and `["tab", "audio"]` is requested, warn end-users.

  - When `"mediaSource"` flag is provided in Firefox, [accept only values](http://fluffy.github.io/w3c-screen-share/#screen-based-video-constraints) like `"screen"`, `"application"`, `"camera"` as described by [bugzilla ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1313758).

    - Additionally accept `"window"` as valid value as [described here](https://bugzilla.mozilla.org/show_bug.cgi?id=1037405).

    - If provided as an `Array`, accept the first valid source value. Example where sources are: `["tab", "screen", "audio", "window"]`, `"screen"` will be selected.

    - For `"browser"` value, the browser preference `media.getusermedia.browser.enabled` value has to be set to `true` in `about:config` as [described here](https://bugzilla.mozilla.org/show_bug.cgi?id=1313758).

- Added screensharing support for Android Chrome 59, where `"mediaSource"` should only accept value of `"screen"`.
  
   - To use and test this, the experimental screensharing flag has to be enabled in `chrome://flags` as [described in here](https://bugs.chromium.org/p/chromium/issues/detail?id=487935).

- Added support for Opera screensharing. This uses the same codebase for the new Chrome extension.

- Added flag `AdapterJS._mediaSourcePolyfillIsDefined` to prevent `AdapterJS._defineMediaSourcePolyfill()` from being invoked again as a form of sanity prevention.

  - Renamed `AdapterJS.defineMediaSourcePolyfill` to `AdapterJS._defineMediaSourcePolyfill` with an added `_` prefix as it's an internal method.

# **Testing**
Note, we should move these test cases to unit tests.
### **How is it tested:**

- For `adapter.screenshare-old.js`,
 go to this [link](https://cdn.temasys.com.sg/adapterjs/0.14.x/adapter.screenshare.js).
- For `adapter.screenshare-new.js`, checkout to this branch, do `grunt publish` and copy the `publish/adapter.screenshare.js` file.
- For `detectRTC-old.html`, go to this [link](https://cdn.temasys.com.sg/skylink/extensions/detectRTC.html).
- For `detectRTC-new.html`, PM.
- For older chrome extension, go to this [link](https://chrome.google.com/webstore/detail/skylink-webrtc-tools/ljckddiekopnnjoeaiofddfhgnbdoafc).
- For new chrome extension, PM.

This uses the `navigator.getUserMedia({ audio: true, video: { mediaSource: xx } })`.

**Chrome**

Use the new extension in development mode.

1. Ensure that when using the new AdapterJS + new DetectRTC + new Chrome extension, whatever `"mediaSource"` is provided is presented as expected. Like `"tab"` should result in displaying a list of browser tabs to select. Like `["tab", "audio"]` should result in being able to select browser tabs and select audio, or `["tab", "audio"]` should return the audio track, or `["screen", "window"]` returns a list of screens or windows to select.

2. Ensure that when using any old AdapterJS / DetectRTC / Chrome extension with new AdapterJS / DetectRTC / Chrome extension should not affect previous functionalities where "window" and "screen" sources is presented.

**Firefox**

1. Ensure that for Firefox 52 when PermissionDenied, the popup installation doesn't trigger.

2. Ensure that for Firefox 51 and below when PermissionDenied, the popup installation does trigger.

3. Ensure that "camera", "browser", "application" are valid sources for `"mediaSource"`.

**Opera**

Use the new extension in development mode.

1. Ensure that screensharing extension triggers for the list of sources.

----

### **Test cases tested:**

**Chrome extension test:**

Extension tested in development mode.

- New Chrome extension version: `0.1.4`
- New DetectRTC version: `0.1.2`

| Result | AdapterJS  | DetectRTC | Chrome Extension |
| ------ | ----------- | ----------- | ----------- |
| PASS  | Branch | `0.1.1` | `0.1.3` |
| PASS  | Branch | `0.1.1` | `0.1.4` |
| PASS  | Branch | `0.1.2` | `0.1.3` |
| PASS  | Branch | `0.1.2` | `0.1.4` |
| PASS  | `0.14.1` | `0.1.1` | `0.1.3` |
| PASS  | `0.14.1` | `0.1.1` | `0.1.4` |
| PASS  | `0.14.1` | `0.1.2` | `0.1.3` |
| PASS  | `0.14.1` | `0.1.2` | `0.1.4` |

**Firefox versions test:**

| Result | Firefox  | Addon installation popup triggered |
| ------ | ----------- | ----------- | 
| PASS  | `52` | No |
| PASS  | `49` | Yes |

**Constraints test:**

Extensions are tested in development mode, except for Firefox. Note that for the current Chrome extension `ljckddiekopnnjoeaiofddfhgnbdoafc` as a fallback alternative will not honour the `"mediaSource"` flag and return `["window", "screen"]` as expected. This should be different in the new Chrome extension when approved.

| Result | Browser             | Constraints - `"mediaSource"`   |
| ------ | ---------------- | -------------------------------- | 
| PASS  | Opera/Chrome   | `"tab"`                                          | 
| PASS  | Opera/Chrome   | `"window" `                                  | 
| PASS  | Opera/Chrome   | `"screen"`                                    | 
| PASS  | Opera/Chrome   | `["tab", "audio"]` audio: `false` | 
| PASS  | Opera/Chrome   | `["tab", "audio"]` audio: `true`  | 
| PASS  | Opera/Chrome   | `["tab", "screen"]`                       | 
| PASS  | Opera/Chrome   | `["tab", "window"]`                     | 
| PASS  | Opera/Chrome   | `["window", "screen"]`               | 
| PASS  | Opera/Chrome   | `["window", "screen", "tab"]`    | 
| PASS  | Chrome Android | `["screen"]` | 
| PASS  | Chrome Android | `"screen"`    | 
| PASS  | Firefox | `["screen"]`        | 
| PASS  | Firefox | `"screen"`          | 
| PASS  | Firefox | `["window"]`      | 
| PASS  | Firefox | `"window"`         | 
| PASS  | Firefox | `["camera"]`       | 
| PASS  | Firefox | `"camera"`         | 
| PASS  | Firefox | `["browser"]`     | 
| PASS  | Firefox | `"browser"`        | 
| PASS  | Firefox | `["application"]` | 
| PASS  | Firefox | `"application"`   | 
| PASS  | Safari/IE | `"screen"` |
| PASS  | Safari/IE | `"window"` |
| PASS  | Safari/IE | `["screen", "window"]` |