### PR TITLE
AJS-284 prevent filtering of mediaSource in contraintsToPlugin

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1121,7 +1121,11 @@ if ( (navigator.mozGetUserMedia ||
       }
       var cc = {};
       Object.keys(c).forEach(function(key) {
-        if (key === 'require' || key === 'advanced' || key === 'mediaSource') {
+        if (key === 'require' || key === 'advanced') {
+          return;
+        }
+        if (typeof c[key] === 'string') {
+          cc[key] = c[key];
           return;
         }
         var r = (typeof c[key] === 'object') ? c[key] : {ideal: c[key]};


### PR DESCRIPTION
Everything is in the title...
This change doesn't actually have any impact at the moment as we still set optional[n].sourceId, but eventually, we want to move away from this system.