### PR TITLE
TWP-721 Allow document.readystate interative

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -154,7 +154,7 @@ AdapterJS.WebRTCPlugin.callWhenPluginReady = null;
 // This function is the only private function that is not encapsulated to
 // allow the plugin method to be called.
 __TemWebRTCReady0 = function () {
-  if (document.readyState === 'complete') {
+  if (document.readyState === 'interactive' || document.readyState === 'complete') {
     AdapterJS.WebRTCPlugin.pluginState = AdapterJS.WebRTCPlugin.PLUGIN_STATES.READY;
     AdapterJS.maybeThroughWebRTCReady();
   } else {
@@ -373,7 +373,7 @@ AdapterJS.addEvent = function(elem, evnt, func) {
 
 AdapterJS.renderNotificationBar = function (message, buttonText, buttonCallback) {
   // only inject once the page is ready
-  if (document.readyState !== 'complete') {
+  if (document.readyState !== 'interactive' && document.readyState !== 'complete') {
     return;
   }
 
@@ -909,7 +909,7 @@ if ( (navigator.mozGetUserMedia ||
 
   AdapterJS.WebRTCPlugin.injectPlugin = function () {
     // only inject once the page is ready
-    if (document.readyState !== 'complete') {
+    if (document.readyState !== 'interactive' && document.readyState !== 'complete') {
       return;
     }
 


### PR DESCRIPTION
In very slow networks, waiting for ```document.readyState``` to move to ```'complete'``` might take a long time (seconds, minutes).
When the readystate is ```'interactive'```, the DOM is ready and the plugin should be able to start.