### PR TITLE
Add polyfill for Array.prototype.forEach.

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -1,3 +1,14 @@
+// Polyfill forEach which is not supported in IE 8
+if (typeof Array.prototype.forEach !== 'function') {
+  Array.prototype.forEach = function (fn) {
+    var index = 0;
+    while (index < this.length) {
+      fn(this[index], index);
+      index++;
+    }
+  };
+}
+
 // Adapter's interface.
 var AdapterJS = AdapterJS || {};
 


### PR DESCRIPTION
Simple PR. Noticed that `Array.prototype.forEach` is used in [line `178`](https://github.com/Temasys/AdapterJS/blob/0.15.0/source/adapter.js#L178), [line `1165`](https://github.com/Temasys/AdapterJS/blob/0.15.0/source/adapter.js#L1165) and [line `1210`](https://github.com/Temasys/AdapterJS/blob/0.15.0/source/adapter.js#L1210). But according the [MDN docs for it](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) IE 8 does not support that function natively although we don't recommend that browser version. This is just to polyfill it when it's missing to prevent errors.