### PR TITLE
AJS-293: Prevent listening to messages that does not come from self to extension

### DIFF
--- a/source/adapter.screenshare.js
+++ b/source/adapter.screenshare.js
@@ -377,16 +377,11 @@ AdapterJS._defineMediaSourcePolyfill = function () {
       // Listen to iframe messages
       var getSourceIdFromIFrame = function (sources, cb) {
         window.addEventListener('message', function iframeListener (evt) {
-          // Unload since it should be replied once if success or failure
-          window.removeEventListener('message', iframeListener);
-          // If no data is returned, it is incorrect
-          if (!evt.data) {
-            cb({
-              success: false,
-              error: new Error('Failed retrieving response')
-            });
+          if (!(evt.data && typeof evt.data === 'object')) {
+            return;
           // Extension not installed
           } else if (evt.data.chromeExtensionStatus === 'not-installed') {
+            window.removeEventListener('message', iframeListener);
             cb({
               success: false,
               error: new Error('Extension is not installed'),
@@ -395,27 +390,24 @@ AdapterJS._defineMediaSourcePolyfill = function () {
             });
           // Extension not enabled
           } else if (evt.data.chromeExtensionStatus === 'installed-disabled') {
+            window.removeEventListener('message', iframeListener);
             cb({
               success: false,
               error: new Error('Extension is disabled')
             });
           // Permission denied for retrieval
           } else if (evt.data.chromeMediaSourceId === 'PermissionDeniedError') {
+            window.removeEventListener('message', iframeListener);
             cb({
               success: false,
               error: new Error('Permission denied for screen retrieval')
             });
           // Source ID retrieved
           } else if (evt.data.chromeMediaSourceId && typeof evt.data.chromeMediaSourceId === 'string') {
+            window.removeEventListener('message', iframeListener);
             cb({
               success: true,
               sourceId: evt.data.chromeMediaSourceId
-            });
-          // Unknown error which is invalid state whereby iframe is not returning correctly and source cannot be retrieved correctly
-          } else {
-            cb({
-              success: false,
-              error: new Error('Failed retrieving selected screen')
             });
           }
         });


### PR DESCRIPTION
This resolves the issue where `getUserMedia({ video: { mediaSource: "screen" } })` for chrome as it listens to all messages in the same page. Currently in the deprecated method which some apps would still be using, the extension would listen to messages from `window.postMessage()` and react upon it. That however is a current problem in the AdapterJS since it is listening to all messages instead of acting upon specific messages, and that causes issues for JS plugins that are using the `window.postMessage()` as well. 

The current PR just simply listens for specific messages instead.