### PR TITLE
Twp 759 document.readyState==='interactive' IE 10

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -11,6 +11,11 @@ AdapterJS.options.getAllCams = !!AdapterJS.options.getAllCams;
 // AdapterJS.options.hidePluginInstallPrompt = true;
 AdapterJS.options.hidePluginInstallPrompt = !!AdapterJS.options.hidePluginInstallPrompt;
 
+// uncomment to allow document.readyState==='interactive" on all browser
+// by default, interactive is not allowed in IE 9 and 10, as it might happen before a <body> is defined
+// AdapterJS.options.alwaysAllowInteractiveState = true;
+AdapterJS.options.alwaysAllowInteractiveState = !!AdapterJS.options.alwaysAllowInteractiveState;
+
 // uncomment to force the use of the plugin on Safari
 // AdapterJS.options.forceSafariPlugin = true;
 AdapterJS.options.forceSafariPlugin = !!AdapterJS.options.forceSafariPlugin;
@@ -153,11 +158,12 @@ AdapterJS.documentReady = function () {
   if (typeof AdapterJS.webrtcDetectedBrowser === 'undefined')
     AdapterJS.parseWebrtcDetectedBrowser();
 
-  if (AdapterJS.webrtcDetectedBrowser === 'IE'
-      && AdapterJS.webrtcDetectedVersion < 11) {
-    return document.readyState === 'complete'; // IE 11 doesn't like readyState interactive
-  } else {
+  if ( AdapterJS.webrtcDetectedBrowser !== 'IE'
+    || AdapterJS.webrtcDetectedVersion > 10 
+    || AdapterJS.options.alwaysAllowInteractiveState) {
     return document.readyState === 'interactive' || document.readyState === 'complete';
+  } else {
+    return document.readyState === 'complete'; // IE 11 doesn't like readyState interactive
   }
 }
 

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -11,11 +11,6 @@ AdapterJS.options.getAllCams = !!AdapterJS.options.getAllCams;
 // AdapterJS.options.hidePluginInstallPrompt = true;
 AdapterJS.options.hidePluginInstallPrompt = !!AdapterJS.options.hidePluginInstallPrompt;
 
-// uncomment to allow document.readyState==='interactive" on all browser
-// by default, interactive is not allowed in IE 9 and 10, as it might happen before a <body> is defined
-// AdapterJS.options.alwaysAllowInteractiveState = true;
-AdapterJS.options.alwaysAllowInteractiveState = !!AdapterJS.options.alwaysAllowInteractiveState;
-
 // uncomment to force the use of the plugin on Safari
 // AdapterJS.options.forceSafariPlugin = true;
 AdapterJS.options.forceSafariPlugin = !!AdapterJS.options.forceSafariPlugin;

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -149,6 +149,18 @@ AdapterJS.WebRTCPlugin.WaitForPluginReady = null;
 // This methid will use an interval to wait for the plugin to be ready.
 AdapterJS.WebRTCPlugin.callWhenPluginReady = null;
 
+AdapterJS.documentReady = function () {
+  if (typeof AdapterJS.webrtcDetectedBrowser === 'undefined')
+    AdapterJS.parseWebrtcDetectedBrowser();
+
+  if (AdapterJS.webrtcDetectedBrowser === 'IE'
+      && AdapterJS.webrtcDetectedVersion < 11) {
+    return document.readyState === 'complete'; // IE 11 doesn't like readyState interactive
+  } else {
+    return document.readyState === 'interactive' || document.readyState === 'complete';
+  }
+}
+
 // !!!! WARNING: DO NOT OVERRIDE THIS FUNCTION. !!!
 // This function will be called when plugin is ready. It sends necessary
 // details to the plugin.
@@ -160,7 +172,7 @@ AdapterJS.WebRTCPlugin.callWhenPluginReady = null;
 // This function is the only private function that is not encapsulated to
 // allow the plugin method to be called.
 __TemWebRTCReady0 = function () {
-  if (document.readyState === 'interactive' || document.readyState === 'complete') {
+  if (AdapterJS.documentReady()) {
     AdapterJS.WebRTCPlugin.pluginState = AdapterJS.WebRTCPlugin.PLUGIN_STATES.READY;
     AdapterJS.maybeThroughWebRTCReady();
   } else {
@@ -384,7 +396,7 @@ AdapterJS.addEvent = function(elem, evnt, func) {
 
 AdapterJS.renderNotificationBar = function (message, buttonText, buttonCallback) {
   // only inject once the page is ready
-  if (document.readyState !== 'interactive' && document.readyState !== 'complete') {
+  if (!AdapterJS.documentReady()) {
     return;
   }
 
@@ -931,7 +943,7 @@ if (['webkit', 'moz', 'ms', 'AppleWebKit'].indexOf(AdapterJS.webrtcDetectedType)
 
   AdapterJS.WebRTCPlugin.injectPlugin = function () {
     // only inject once the page is ready
-    if (document.readyState !== 'interactive' && document.readyState !== 'complete') {
+    if (!AdapterJS.documentReady()) {
       return;
     }
 

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -155,16 +155,7 @@ AdapterJS.WebRTCPlugin.WaitForPluginReady = null;
 AdapterJS.WebRTCPlugin.callWhenPluginReady = null;
 
 AdapterJS.documentReady = function () {
-  if (typeof AdapterJS.webrtcDetectedBrowser === 'undefined')
-    AdapterJS.parseWebrtcDetectedBrowser();
-
-  if ( AdapterJS.webrtcDetectedBrowser !== 'IE'
-    || AdapterJS.webrtcDetectedVersion > 10 
-    || AdapterJS.options.alwaysAllowInteractiveState) {
-    return document.readyState === 'interactive' || document.readyState === 'complete';
-  } else {
-    return document.readyState === 'complete'; // IE 11 doesn't like readyState interactive
-  }
+  return (document.readyState === 'interactive' && !!document.body) || document.readyState === 'complete';
 }
 
 // !!!! WARNING: DO NOT OVERRIDE THIS FUNCTION. !!!


### PR DESCRIPTION
Waiting on customer validation in this ticket https://jira.temasys.com.sg/browse/TWP-759
In the meantime, I just want your pre-approval of the changes, so that I can merge asap.

Logic implemented : we support document.readyState==='interactive', on all browsers but IE < 11. Set the flag AdapterJS.options.alwaysAllowInteractiveState to true, to enable document.readyState==='interactive' on IE < 11