### PR TITLE
Add bind() polyfill to plugin functions

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -382,6 +382,23 @@ AdapterJS.addEvent = function(elem, evnt, func) {
   }
 };
 
+AdapterJS.recursivePolyfillBind(obj) {
+  if (!obj) {
+    return;
+  }
+
+  var pluginProperties = Object.keys(obj);
+  for (var i = 0; i < pluginProperties.length; i++) {
+    var currentProperty = obj[pluginProperties[i]];
+
+    if (typeof currentProperty === 'function' && !currentProperty.bind) {
+      currentProperty.bind = Function.prototype.bind;
+    } else if(typeof currentProperty === 'object') {
+      AdapterJS.recursivePolyfillBind(currentProperty);
+    }
+  }
+}
+
 AdapterJS.renderNotificationBar = function (message, buttonText, buttonCallback) {
   // only inject once the page is ready
   if (document.readyState !== 'interactive' && document.readyState !== 'complete') {
@@ -1133,7 +1150,11 @@ if (['webkit', 'moz', 'ms', 'AppleWebKit'].indexOf(AdapterJS.webrtcDetectedType)
         if (iceServers) {
           servers.iceServers = iceServers;
         }
-        return AdapterJS.WebRTCPlugin.plugin.PeerConnection(servers);
+        
+        // polyfill plugin functions with bind()
+        var peerConnection = AdapterJS.WebRTCPlugin.plugin.PeerConnection(servers);
+        AdapterJS.recursivePolyfillBind(peerConnection);
+        return peerConnection;
       } else {
         var mandatory = (constraints && constraints.mandatory) ?
           constraints.mandatory : null;


### PR DESCRIPTION
The Temasys plugin returns Javascript functions that reflect a much older version of Javascript and do not support the `bind()` functionality which causes failures in our code and some plugins like [rtcpeerconnection](https://github.com/otalk/RTCPeerConnection). This recursively polyfills all functions on the plugin object so they support this relatively recent Javascript functionality.