### PR TITLE
Added check for navigator.mimeTypes undefined. Should show plugin not supported banner

### DIFF
--- a/source/adapter.js
+++ b/source/adapter.js
@@ -843,7 +843,6 @@ if (['webkit', 'moz', 'ms', 'AppleWebKit'].indexOf(AdapterJS.webrtcDetectedType)
         notInstalledCb();
       } else {
         AdapterJS.renderNotificationBar(AdapterJS.TEXT.PLUGIN.NOT_SUPPORTED);
-        notInstalledCb();
       }
     } else {
       try {

--- a/source/adapter.js
+++ b/source/adapter.js
@@ -833,13 +833,18 @@ if (['webkit', 'moz', 'ms', 'AppleWebKit'].indexOf(AdapterJS.webrtcDetectedType)
     function (comName, plugName, plugType, installedCb, notInstalledCb) {
     if (AdapterJS.webrtcDetectedBrowser !== 'IE') {
       var pluginArray = navigator.mimeTypes;
-      for (var i = 0; i < pluginArray.length; i++) {
-        if (pluginArray[i].type.indexOf(plugType) >= 0) {
-          installedCb();
-          return;
+      if (typeof pluginArray !== 'undefined') {
+        for (var i = 0; i < pluginArray.length; i++) {
+          if (pluginArray[i].type.indexOf(plugType) >= 0) {
+            installedCb();
+            return;
+          }
         }
+        notInstalledCb();
+      } else {
+        AdapterJS.renderNotificationBar(AdapterJS.TEXT.PLUGIN.NOT_SUPPORTED);
+        notInstalledCb();
       }
-      notInstalledCb();
     } else {
       try {
         var axo = new ActiveXObject(comName + '.' + plugName);


### PR DESCRIPTION
**Purpose of this PR**

In situations where navigator.mimeTypes are not available (headless browsers), the AJS code needs to make a safe check and display plugin not supported banner.